### PR TITLE
Add Mod to Keybinding

### DIFF
--- a/event.go
+++ b/event.go
@@ -22,6 +22,7 @@ const (
 type KeyEvent struct {
 	Key  Key
 	Rune rune
+	Mod  ModMask
 }
 
 type MouseEvent struct {
@@ -31,3 +32,57 @@ type MouseEvent struct {
 type PaintEvent struct{}
 
 type Event interface{}
+
+type HEvent struct {
+	Key       Key
+	Rune      rune
+	Modifiers ModMask
+}
+
+type ModMask int16
+
+const (
+	ModShift ModMask = 1 << iota
+	ModCtrl
+	ModAlt
+	ModMeta
+	ModNone ModMask = 0
+)
+
+// When an Event is fired in tcell, the ev.Ch pressed
+// is modified by Ctrl. So that 'n' (110) -> 14
+// when the Mod Ctrl, (2) is pressed.
+const (
+	KeyCtrlSpace rune = iota
+	KeyCtrlA
+	KeyCtrlB
+	KeyCtrlC
+	KeyCtrlD
+	KeyCtrlE
+	KeyCtrlF
+	KeyCtrlG
+	KeyCtrlH
+	KeyCtrlI
+	KeyCtrlJ
+	KeyCtrlK
+	KeyCtrlL
+	KeyCtrlM
+	KeyCtrlN
+	KeyCtrlO
+	KeyCtrlP
+	KeyCtrlQ
+	KeyCtrlR
+	KeyCtrlS
+	KeyCtrlT
+	KeyCtrlU
+	KeyCtrlV
+	KeyCtrlW
+	KeyCtrlX
+	KeyCtrlY
+	KeyCtrlZ
+	KeyCtrlLeftSq // Escape
+	KeyCtrlBackslash
+	KeyCtrlRightSq
+	KeyCtrlCarat
+	KeyCtrlUnderscore
+)

--- a/keybinding.go
+++ b/keybinding.go
@@ -1,12 +1,16 @@
 package tui
 
 type Keybinding struct {
-	Key  Key
-	Rune rune
-
+	Key     Key
+	Rune    rune
+	Mod     ModMask
 	Handler func()
 }
 
 func (b *Keybinding) Match(ev KeyEvent) bool {
+	if b.Key != KeyUnknown {
+		return b.Rune == ev.Rune && b.Mod == ev.Mod
+	}
+
 	return b.Key == ev.Key && b.Rune == ev.Rune
 }

--- a/keybinding_test.go
+++ b/keybinding_test.go
@@ -10,6 +10,8 @@ func TestKeybinding_Match(t *testing.T) {
 	}{
 		{Keybinding{Rune: 'a'}, KeyEvent{Rune: 'a'}, true},
 		{Keybinding{Rune: 'a'}, KeyEvent{Rune: 'l'}, false},
+		{Keybinding{Rune: KeyCtrlN, Mod: ModCtrl}, KeyEvent{Rune: KeyCtrlN, Mod: ModCtrl}, true},
+		{Keybinding{Rune: 'n', Mod: ModCtrl}, KeyEvent{Rune: KeyCtrlN, Mod: ModCtrl}, false},
 		{Keybinding{Key: KeyEnter}, KeyEvent{Rune: 'l'}, false},
 		{Keybinding{Key: KeyEnter}, KeyEvent{Key: KeyEnter}, true},
 	} {

--- a/ui.go
+++ b/ui.go
@@ -2,7 +2,7 @@ package tui
 
 type UI interface {
 	SetTheme(p *Theme)
-	SetKeybinding(k interface{}, fn func())
+	SetKeybinding(k interface{}, m ModMask, fn func())
 	SetFocusChain(ch FocusChain)
 	Run() error
 	Quit()

--- a/ui_tcell.go
+++ b/ui_tcell.go
@@ -55,16 +55,19 @@ func (ui *tcellUI) SetFocusChain(chain FocusChain) {
 	ui.kbFocus.chain = chain
 }
 
-func (ui *tcellUI) SetKeybinding(k interface{}, fn func()) {
+func (ui *tcellUI) SetKeybinding(k interface{}, m ModMask, fn func()) {
 	kb := new(Keybinding)
-
+	kb.Handler = fn
 	switch key := k.(type) {
 	case rune:
 		kb.Rune = key
 	case Key:
 		kb.Key = key
 	}
-	kb.Handler = fn
+
+	if m != ModNone {
+		kb.Mod = m
+	}
 
 	ui.keybindings = append(ui.keybindings, kb)
 }


### PR DESCRIPTION
Sooo I noticed you made a few changes since I've last pulled, which I then reverted 😅 in order to add this Mod functionality... 

I didn't get what was going on before, because, strangely, the event fired from tcell when a Mod key is pressed, **actually modifies** the `Ch`/`rune` that is sent along in the event. As I mentioned in the comments, 

`'n' == 110` , however when pressed with the modifier Ctrl, `'n' == 14`. That's why I added (or rather copied form `tcell` the enum for `KeyCtrlN` etc.

Now for adding other Modifiers, I figure it's along the same lines, I bet, but I didn't want to put to much time into this pr if you didn't want to go in this direction in any case (seeing as how I reverted some of the changes you made).

So if it is indeed the direction you're interested in, I can add the other Mods and/or remove/add some comments. Also, I added a wee bit to the test but it's tricky to test because the thing I _want_ to test is coming from the tcell event `chan` -- and I'm not sure how to go about mocking that.

Anyway, now that this functionality is up (on my fork at least) I can have those glorious emacs keybindings I've been wanting 😄 