### PR TITLE
Remove cursor before every paint to clean up

### DIFF
--- a/painter.go
+++ b/painter.go
@@ -8,6 +8,7 @@ import (
 type Surface interface {
 	SetCell(x, y int, ch rune, s Style)
 	SetCursor(x, y int)
+	HideCursor()
 	Begin()
 	End()
 	Size() image.Point
@@ -64,6 +65,7 @@ func (p *Painter) End() {
 func (p *Painter) Repaint(w Widget) {
 	p.Begin()
 	w.Resize(p.surface.Size())
+	p.surface.HideCursor()
 	w.Draw(p)
 	p.End()
 }

--- a/painter_test.go
+++ b/painter_test.go
@@ -36,6 +36,10 @@ func (s *testSurface) SetCursor(x, y int) {
 	s.cursor = image.Point{x, y}
 }
 
+func (s *testSurface) HideCursor() {
+	s.cursor = image.Point{}
+}
+
 func (s *testSurface) Begin() {
 	s.cells = make(map[image.Point]testCell)
 }

--- a/ui_tcell.go
+++ b/ui_tcell.go
@@ -179,6 +179,10 @@ func (s *tcellSurface) SetCursor(x, y int) {
 	s.screen.ShowCursor(x, y)
 }
 
+func (s *tcellSurface) HideCursor() {
+	s.screen.HideCursor()
+}
+
 func (s *tcellSurface) Begin() {
 	s.screen.Clear()
 }


### PR DESCRIPTION
I noticed that when I take focus away from an entry and focus on a button, the cursor is left behind.

I think this is because the painter will set the cursor if an entry is focussed, but never clear it.

This PR will remove the cursor before every repaint, so that the widget that is focussed can put it back in the right place, if at all!