### PR TITLE
Some Label changes

### DIFF
--- a/label.go
+++ b/label.go
@@ -78,8 +78,8 @@ func (l *Label) heightForWidth(w int) int {
 	return len(strings.Split(wordwrap.WrapString(l.text, uint(w)), "\n"))
 }
 
-// GetText returns the text content of the label.
-func (l *Label) GetText() string {
+// Text returns the text content of the label.
+func (l *Label) Text() string {
 	return l.text
 }
 

--- a/label.go
+++ b/label.go
@@ -61,6 +61,9 @@ func (l *Label) SizeHint() image.Point {
 	}
 	var max int
 	lines := strings.Split(l.text, "\n")
+	if l.wordWrap {
+		lines = strings.Split(wordwrap.WrapString(l.text, uint(l.Size().X)), "\n")
+	}
 	for _, line := range lines {
 		if w := stringWidth(line); w > max {
 			max = w
@@ -73,6 +76,11 @@ func (l *Label) SizeHint() image.Point {
 
 func (l *Label) heightForWidth(w int) int {
 	return len(strings.Split(wordwrap.WrapString(l.text, uint(w)), "\n"))
+}
+
+// GetText returns the text content of the label.
+func (l *Label) GetText() string {
+	return l.text
 }
 
 // SetText sets the text content of the label.


### PR DESCRIPTION
This PR fixes an issue I found where `SizeHint` was suggesting too small of a size when word wrapping was triggered.

Included is a `GetText` function to retrieve the current text contents.