### PR TITLE
Add readline functionality to Entry and TextEdit

### DIFF
--- a/example/editor/main.go
+++ b/example/editor/main.go
@@ -7,10 +7,11 @@ import (
 func main() {
 	buffer := tui.NewTextEdit()
 	buffer.SetSizePolicy(tui.Expanding, tui.Expanding)
-	buffer.SetText("Hello, world!")
+	buffer.SetText(body)
 	buffer.SetFocused(true)
+	buffer.SetWordWrap(true)
 
-	status := tui.NewStatusBar("main.go")
+	status := tui.NewStatusBar("lorem.txt")
 
 	root := tui.NewVBox(buffer, status)
 
@@ -21,3 +22,11 @@ func main() {
 		panic(err)
 	}
 }
+
+const body = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque elementum dui vitae nisl scelerisque porta. Proin orci mauris, imperdiet ac venenatis id, interdum fermentum ligula. Praesent risus odio, pharetra ac maximus in, tincidunt eget nibh. Vestibulum pretium molestie fermentum. Aenean sed neque purus. Vivamus vitae nulla nec ligula ultrices lacinia. Ut in vulputate ante. Proin lacinia eleifend varius. Cras quis urna eget nisi efficitur tristique sed vitae nibh. Nam ac nisi libero. In interdum volutpat elementum. Nulla lorem magna, efficitur interdum ante at, convallis sodales nulla. Sed maximus tempor condimentum.
+
+Nam et risus est. Cras ornare iaculis orci, sit amet fringilla nisl pharetra quis. Integer quis sem porttitor, gravida nisi eget, feugiat lacus. Aliquam aliquet quam eget ipsum ultrices, in viverra ex dapibus. Sed ullamcorper, justo sit amet feugiat faucibus, nisl sem hendrerit dui, non tincidunt lacus turpis non tortor. Aenean nisl justo, dictum non eros quis, luctus pulvinar urna. Ut finibus odio id nunc rutrum iaculis.
+
+Nam commodo tempor augue, nec facilisis nulla pretium scelerisque. Donec eu interdum nisl. Aliquam dui nisl, venenatis id velit ac, ultrices faucibus massa. Suspendisse id condimentum augue. Sed a libero ornare, sollicitudin neque sed, blandit nunc. Quisque sed sem non erat pharetra semper. Mauris molestie leo ante, in varius elit ullamcorper at. Suspendisse sed scelerisque velit, eget rutrum nunc. Cras in ultrices risus. Aliquam maximus, purus in consequat rutrum, erat mauris pharetra lacus, nec interdum turpis metus non velit. Cras in lobortis tortor, vitae dignissim mauris. Phasellus nec massa nisi. Etiam auctor, odio egestas egestas ullamcorper, mauris risus maximus nisl, eget faucibus risus dui sed nisi. Sed ligula mi, egestas in augue vitae, tincidunt molestie sapien.
+
+Maecenas eget tristique dolor. Quisque vel velit ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Pellentesque lorem diam, feugiat ut odio et, tempus consequat mauris. Phasellus lobortis sodales tellus, sed aliquam lectus lobortis id. Nulla mollis tempor elit. Etiam luctus convallis justo, sed viverra nibh sodales eget. Aliquam blandit, felis eget accumsan tempus, orci magna molestie metus, vel bibendum nibh risus at augue. Maecenas vulputate feugiat dui sit amet facilisis. In et eros vel elit vestibulum laoreet at id mauris. Nullam tincidunt suscipit diam, vel sollicitudin massa venenatis id. Fusce porttitor urna et aliquam dignissim. Maecenas mollis ligula ut ex maximus, vel feugiat metus scelerisque. Sed pharetra ac nunc in pharetra.`

--- a/runebuf.go
+++ b/runebuf.go
@@ -1,0 +1,160 @@
+package tui
+
+import (
+	"image"
+	"strings"
+
+	runewidth "github.com/mattn/go-runewidth"
+	wordwrap "github.com/mitchellh/go-wordwrap"
+)
+
+// RuneBuffer provides readline functionality for text widgets.
+type RuneBuffer struct {
+	buf []rune
+	idx int
+
+	wordwrap bool
+}
+
+// Width returns the width of the rune buffer, taking into account for CJK.
+func (r *RuneBuffer) Width() int {
+	return runewidth.StringWidth(string(r.buf))
+}
+
+// Set the buffer and the index at the end of the buffer.
+func (r *RuneBuffer) Set(buf []rune) {
+	r.SetWithIdx(len(buf), buf)
+}
+
+// SetWithIdx set the the buffer with a given index.
+func (r *RuneBuffer) SetWithIdx(idx int, buf []rune) {
+	r.buf = buf
+	r.idx = idx
+}
+
+// WriteRune appends a rune to the buffer.
+func (r *RuneBuffer) WriteRune(s rune) {
+	r.WriteRunes([]rune{s})
+}
+
+// WriteRunes appends runes to the buffer.
+func (r *RuneBuffer) WriteRunes(s []rune) {
+	tail := append(s, r.buf[r.idx:]...)
+	r.buf = append(r.buf[:r.idx], tail...)
+	r.idx += len(s)
+}
+
+// Pos returns the current index in the buffer.
+func (r *RuneBuffer) Pos() int {
+	return r.idx
+}
+
+// Len returns the number of runes in the buffer.
+func (r *RuneBuffer) Len() int {
+	return len(r.buf)
+}
+
+// SplitByLine returns the lines for a given width.
+func (r *RuneBuffer) SplitByLine(width int) []string {
+	var text string
+	if r.wordwrap {
+		text = wordwrap.WrapString(r.String(), uint(width))
+	} else {
+		text = r.String()
+	}
+	return strings.Split(text, "\n")
+}
+
+func getSplitByLine(rs []rune, width int, wrap bool) []string {
+	var text string
+	if wrap {
+		text = wordwrap.WrapString(string(rs), uint(width))
+	} else {
+		text = string(rs)
+	}
+	return strings.Split(text, "\n")
+}
+
+// CursorPos returns the coordinate for the cursor for a given width.
+func (r *RuneBuffer) CursorPos(width int) image.Point {
+	if width == 0 {
+		return image.ZP
+	}
+
+	sp := getSplitByLine(r.buf[:r.idx], width, r.wordwrap)
+
+	return image.Pt(stringWidth(sp[len(sp)-1]), len(sp)-1)
+}
+
+func (r *RuneBuffer) String() string {
+	return string(r.buf)
+}
+
+// MoveBackward moves the cursor back by one rune.
+func (r *RuneBuffer) MoveBackward() {
+	if r.idx == 0 {
+		return
+	}
+	r.idx--
+}
+
+// MoveForward moves the cursor forward by one rune.
+func (r *RuneBuffer) MoveForward() {
+	if r.idx == len(r.buf) {
+		return
+	}
+	r.idx++
+}
+
+// MoveToLineStart moves the cursor to the start of the current line.
+func (r *RuneBuffer) MoveToLineStart() {
+	for i := r.idx; i > 0; i-- {
+		if r.buf[i-1] == '\n' {
+			r.idx = i
+			return
+		}
+	}
+	r.idx = 0
+}
+
+// MoveToLineEnd moves the cursor to the end of the current line.
+func (r *RuneBuffer) MoveToLineEnd() {
+	for i := r.idx; i < len(r.buf)-1; i++ {
+		if r.buf[i+1] == '\n' {
+			r.idx = i
+			return
+		}
+	}
+	r.idx = len(r.buf)
+}
+
+// Backspace deletes the rune left of the cursor.
+func (r *RuneBuffer) Backspace() {
+	if r.idx == 0 {
+		return
+	}
+	r.idx--
+	r.buf = append(r.buf[:r.idx], r.buf[r.idx+1:]...)
+}
+
+// Delete deletes the rune at the current cursor position.
+func (r *RuneBuffer) Delete() {
+	if r.idx == len(r.buf) {
+		return
+	}
+	r.buf = append(r.buf[:r.idx], r.buf[r.idx+1:]...)
+}
+
+// Kill deletes all runes from the cursor until the end of the line.
+func (r *RuneBuffer) Kill() {
+	newlineIdx := strings.IndexRune(string(r.buf[r.idx:]), '\n')
+	if newlineIdx < 0 {
+		r.buf = r.buf[:r.idx]
+	} else {
+		r.buf = append(r.buf[:r.idx], r.buf[r.idx+newlineIdx+1:]...)
+	}
+}
+
+func (r *RuneBuffer) heightForWidth(w int) int {
+	return len(r.SplitByLine(w))
+}

--- a/runebuf_test.go
+++ b/runebuf_test.go
@@ -1,0 +1,176 @@
+package tui
+
+import (
+	"image"
+	"reflect"
+	"testing"
+)
+
+func TestRuneBuffer_MoveToLineStart(t *testing.T) {
+	for _, tt := range []struct {
+		curr RuneBuffer
+		want RuneBuffer
+	}{
+		{RuneBuffer{idx: 3, buf: []rune("foo")}, RuneBuffer{idx: 0, buf: []rune("foo")}},
+		{RuneBuffer{idx: 0, buf: []rune("foo")}, RuneBuffer{idx: 0, buf: []rune("foo")}},
+	} {
+		t.Run("", func(t *testing.T) {
+			tt.curr.MoveToLineStart()
+
+			if tt.want.idx != tt.curr.idx {
+				t.Fatalf("want = %v; got = %v", tt.want.idx, tt.curr.idx)
+			}
+			if !reflect.DeepEqual(tt.want.buf, tt.curr.buf) {
+				t.Fatalf("want = %v; got = %v", tt.want.buf, tt.curr.buf)
+			}
+		})
+	}
+}
+
+func TestRuneBuffer_MoveToLineEnd(t *testing.T) {
+	for _, tt := range []struct {
+		curr RuneBuffer
+		want RuneBuffer
+	}{
+		{RuneBuffer{idx: 3, buf: []rune("foo")}, RuneBuffer{idx: 3, buf: []rune("foo")}},
+		{RuneBuffer{idx: 0, buf: []rune("foo")}, RuneBuffer{idx: 3, buf: []rune("foo")}},
+	} {
+		t.Run("", func(t *testing.T) {
+			tt.curr.MoveToLineEnd()
+
+			if tt.want.idx != tt.curr.idx {
+				t.Fatalf("want = %v; got = %v", tt.want.idx, tt.curr.idx)
+			}
+			if !reflect.DeepEqual(tt.want.buf, tt.curr.buf) {
+				t.Fatalf("want = %v; got = %v", tt.want.buf, tt.curr.buf)
+			}
+		})
+	}
+}
+
+func TestRuneBuffer_Backspace(t *testing.T) {
+	for _, tt := range []struct {
+		curr RuneBuffer
+		want RuneBuffer
+	}{
+		{RuneBuffer{idx: 0, buf: []rune("foo bar")}, RuneBuffer{idx: 0, buf: []rune("foo bar")}},
+		{RuneBuffer{idx: 1, buf: []rune("foo bar")}, RuneBuffer{idx: 0, buf: []rune("oo bar")}},
+		{RuneBuffer{idx: 7, buf: []rune("foo bar")}, RuneBuffer{idx: 6, buf: []rune("foo ba")}},
+		{RuneBuffer{idx: 4, buf: []rune("foo bar")}, RuneBuffer{idx: 3, buf: []rune("foobar")}},
+	} {
+		t.Run("", func(t *testing.T) {
+			tt.curr.Backspace()
+
+			if tt.want.idx != tt.curr.idx {
+				t.Fatalf("want = %v; got = %v", tt.want.idx, tt.curr.idx)
+			}
+			if !reflect.DeepEqual(tt.want.buf, tt.curr.buf) {
+				t.Fatalf("want = %q; got = %q", string(tt.want.buf), string(tt.curr.buf))
+			}
+		})
+	}
+}
+
+func TestRuneBuffer_Kill(t *testing.T) {
+	for _, tt := range []struct {
+		curr RuneBuffer
+		want RuneBuffer
+	}{
+		{RuneBuffer{idx: 0, buf: []rune("foo bar")}, RuneBuffer{idx: 0, buf: []rune("")}},
+		{RuneBuffer{idx: 1, buf: []rune("foo bar")}, RuneBuffer{idx: 1, buf: []rune("f")}},
+		{RuneBuffer{idx: 7, buf: []rune("foo bar")}, RuneBuffer{idx: 7, buf: []rune("foo bar")}},
+		{RuneBuffer{idx: 4, buf: []rune("foo bar")}, RuneBuffer{idx: 4, buf: []rune("foo ")}},
+		{RuneBuffer{idx: 0, buf: []rune("foo \nbar")}, RuneBuffer{idx: 0, buf: []rune("bar")}},
+		{RuneBuffer{idx: 5, buf: []rune("foo \nbar")}, RuneBuffer{idx: 5, buf: []rune("foo \n")}},
+		{RuneBuffer{idx: 6, buf: []rune("foo \nbar")}, RuneBuffer{idx: 6, buf: []rune("foo \nb")}},
+		{RuneBuffer{idx: 0, buf: []rune("\n")}, RuneBuffer{idx: 0, buf: []rune("")}},
+	} {
+		t.Run("", func(t *testing.T) {
+			tt.curr.Kill()
+
+			if tt.want.idx != tt.curr.idx {
+				t.Fatalf("want = %v; got = %v", tt.want.idx, tt.curr.idx)
+			}
+			if !reflect.DeepEqual(tt.want.buf, tt.curr.buf) {
+				t.Fatalf("want = %q; got = %q", string(tt.want.buf), string(tt.curr.buf))
+			}
+		})
+	}
+}
+
+func TestRuneBuffer_CursorPos(t *testing.T) {
+	for _, tt := range []struct {
+		text        string
+		screenWidth int
+		idx         int
+		out         image.Point
+	}{
+		{"Lorem ipsum dolor sit amet.", 12, 27, image.Pt(5, 2)},
+		{"Lorem ipsum dolor sit amet.", 16, 27, image.Pt(15, 1)},
+		{"Lorem ipsum dolor sit amet.", 27, 20, image.Pt(20, 0)},
+	} {
+		t.Run("", func(t *testing.T) {
+			var r RuneBuffer
+			r.wordwrap = true
+			r.SetWithIdx(tt.idx, []rune(tt.text))
+
+			if got := r.CursorPos(tt.screenWidth); tt.out != got {
+				t.Fatalf("want = %s; got = %s", tt.out, got)
+			}
+		})
+
+	}
+}
+
+func TestRuneBuffer_SplitByLines(t *testing.T) {
+	for _, tt := range []struct {
+		text  string
+		width int
+		wrap  bool
+		want  []string
+	}{
+		{"Lorem ipsum dolor sit amet.", 12, true, []string{"Lorem ipsum", "dolor sit", "amet."}},
+		{"Lorem ipsum dolor sit amet.", 27, true, []string{"Lorem ipsum dolor sit amet."}},
+		{"Lorem ipsum dolor sit amet.", 12, false, []string{"Lorem ipsum dolor sit amet."}},
+	} {
+		got := getSplitByLine([]rune(tt.text), tt.width, tt.wrap)
+		if !reflect.DeepEqual(tt.want, got) {
+			t.Fatalf("want = %#v; got = %#v", tt.want, got)
+		}
+	}
+}
+
+func TestRuneBuffer_CursorPosWithWordWrap(t *testing.T) {
+	for _, tt := range []struct {
+		text        string
+		screenWidth int
+		idx         int
+		wrap        bool
+		want        image.Point
+	}{
+		// Lorem ipsum
+		// dolor sit amet.
+		{"Lorem ipsum dolor sit amet.", 12, 11, true, image.Pt(11, 0)},
+		{"Lorem ipsum dolor sit amet.", 12, 12, true, image.Pt(0, 1)},
+		{"Lorem ipsum dolor sit amet.", 12, 13, true, image.Pt(1, 1)},
+
+		// Lorem ipsum dolor
+		// sit amet.
+		{"Lorem ipsum dolor sit amet.", 19, 17, true, image.Pt(17, 0)},
+		{"Lorem ipsum dolor sit amet.", 19, 18, true, image.Pt(0, 1)},
+		{"Lorem ipsum dolor sit amet.", 19, 19, true, image.Pt(1, 1)},
+		{"Lorem ipsum dolor sit amet.", 19, 20, true, image.Pt(2, 1)},
+		{"Lorem ipsum dolor sit amet.", 19, 21, true, image.Pt(3, 1)},
+	} {
+		t.Skip("Skip until a more sophisticated word wrap has been implemented.")
+		t.Run("", func(t *testing.T) {
+			var r RuneBuffer
+			r.wordwrap = tt.wrap
+			r.SetWithIdx(tt.idx, []rune(tt.text))
+
+			if got := r.CursorPos(tt.screenWidth); tt.want != got {
+				t.Fatalf("want = %s; got = %s", tt.want, got)
+			}
+		})
+	}
+}

--- a/text_edit_test.go
+++ b/text_edit_test.go
@@ -17,6 +17,7 @@ var drawTextEditTests = []struct {
 		setup: func() *TextEdit {
 			e := NewTextEdit()
 			e.SetText("Lorem ipsum dolor sit amet")
+			e.SetWordWrap(true)
 			return e
 		},
 		want: `


### PR DESCRIPTION
This PR introduces a rune buffer (inspired by [chzyer/readline](https://github.com/chzyer/readline/blob/master/runebuf.go) to add basic readline functionality to `Entry` and `TextEdit`.

Fixes #17 and #51