### PR TITLE
Implement whitespace preserving wordwrap

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -32,6 +32,7 @@ func (e *Entry) Draw(p *Painter) {
 	}
 	p.WithStyle(style, func(p *Painter) {
 		s := e.Size()
+		e.text.SetMaxWidth(s.X)
 
 		text := e.visibleText()
 
@@ -39,7 +40,7 @@ func (e *Entry) Draw(p *Painter) {
 		p.DrawText(0, 0, text)
 
 		if e.IsFocused() {
-			pos := e.text.CursorPos(s.X)
+			pos := e.text.CursorPos()
 			p.DrawCursor(pos.X-e.offset, 0)
 		}
 	})
@@ -55,6 +56,9 @@ func (e *Entry) OnKeyEvent(ev KeyEvent) {
 	if !e.IsFocused() {
 		return
 	}
+
+	screenWidth := e.Size().X
+	e.text.SetMaxWidth(screenWidth)
 
 	if ev.Key != KeyRune {
 		switch ev.Key {
@@ -83,8 +87,7 @@ func (e *Entry) OnKeyEvent(ev KeyEvent) {
 		case KeyRight, KeyCtrlF:
 			e.text.MoveForward()
 
-			screenWidth := e.Size().X
-			isCursorTooFar := e.text.CursorPos(screenWidth).X >= screenWidth
+			isCursorTooFar := e.text.CursorPos().X >= screenWidth
 			isTextLeft := (e.text.Width() - e.offset) > (screenWidth - 1)
 
 			if isCursorTooFar && isTextLeft {
@@ -95,7 +98,7 @@ func (e *Entry) OnKeyEvent(ev KeyEvent) {
 			e.offset = 0
 		case KeyEnd, KeyCtrlE:
 			e.text.MoveToLineEnd()
-			left := e.text.Width() - (e.Size().X - 1)
+			left := e.text.Width() - (screenWidth - 1)
 			if left >= 0 {
 				e.offset = left
 			}
@@ -106,7 +109,7 @@ func (e *Entry) OnKeyEvent(ev KeyEvent) {
 	}
 
 	e.text.WriteRune(ev.Rune)
-	if e.text.CursorPos(e.Size().X).X >= e.Size().X {
+	if e.text.CursorPos().X >= screenWidth {
 		e.offset++
 	}
 	if e.onTextChange != nil {

--- a/entry_test.go
+++ b/entry_test.go
@@ -386,6 +386,7 @@ func TestEntry_MoveToStartAndEnd(t *testing.T) {
 		e := NewEntry()
 		e.SetText("Lorem ipsum")
 		e.SetFocused(true)
+		e.text.SetMaxWidth(5)
 		e.offset = 6
 
 		surface := newTestSurface(5, 1)
@@ -397,7 +398,7 @@ func TestEntry_MoveToStartAndEnd(t *testing.T) {
 
 			want := "\nLorem\n"
 
-			if got := e.text.CursorPos(5); got.X != 0 {
+			if got := e.text.CursorPos(); got.X != 0 {
 				t.Errorf("cursor position should be %d, but was %d", 0, got.X)
 			}
 			if e.offset != 0 {
@@ -413,7 +414,7 @@ func TestEntry_MoveToStartAndEnd(t *testing.T) {
 
 			want := "\npsum \n"
 
-			if got := e.text.CursorPos(5); got.X != 11 {
+			if got := e.text.CursorPos(); got.X != 11 {
 				t.Errorf("cursor position should be %d, but was %d", 11, got.X)
 			}
 			if e.offset != 7 {
@@ -430,6 +431,7 @@ func TestEntry_OnKeyBackspaceEvent(t *testing.T) {
 		e := NewEntry()
 		e.SetText("Lorem ipsum")
 		e.SetFocused(true)
+		e.text.SetMaxWidth(5)
 		e.offset = 6
 
 		surface := newTestSurface(5, 1)
@@ -441,7 +443,7 @@ func TestEntry_OnKeyBackspaceEvent(t *testing.T) {
 
 			want := "\nm ips\n"
 
-			if got := e.text.CursorPos(5); got.X != 9 {
+			if got := e.text.CursorPos(); got.X != 9 {
 				t.Errorf("cursor position should be %d, but was %d", 9, got.X)
 			}
 			if e.offset != 4 {

--- a/text_edit.go
+++ b/text_edit.go
@@ -30,14 +30,15 @@ func (e *TextEdit) Draw(p *Painter) {
 	}
 	p.WithStyle(style, func(p *Painter) {
 		s := e.Size()
+		e.text.SetMaxWidth(s.X)
 
-		lines := e.text.SplitByLine(s.X)
+		lines := e.text.SplitByLine()
 		for i, line := range lines {
 			p.FillRect(0, i, s.X, 1)
 			p.DrawText(0, i, line)
 		}
 		if e.IsFocused() {
-			pos := e.text.CursorPos(s.X)
+			pos := e.text.CursorPos()
 			p.DrawCursor(pos.X, pos.Y)
 		}
 	})
@@ -60,6 +61,9 @@ func (e *TextEdit) OnKeyEvent(ev KeyEvent) {
 	if !e.IsFocused() {
 		return
 	}
+
+	screenWidth := e.Size().X
+	e.text.SetMaxWidth(screenWidth)
 
 	if ev.Key != KeyRune {
 		switch ev.Key {
@@ -86,8 +90,7 @@ func (e *TextEdit) OnKeyEvent(ev KeyEvent) {
 		case KeyRight, KeyCtrlF:
 			e.text.MoveForward()
 
-			screenWidth := e.Size().X
-			isCursorTooFar := e.text.CursorPos(screenWidth).X >= screenWidth
+			isCursorTooFar := e.text.CursorPos().X >= screenWidth
 			isTextLeft := (e.text.Width() - e.offset) > (screenWidth - 1)
 
 			if isCursorTooFar && isTextLeft {
@@ -98,7 +101,7 @@ func (e *TextEdit) OnKeyEvent(ev KeyEvent) {
 			e.offset = 0
 		case KeyEnd, KeyCtrlE:
 			e.text.MoveToLineEnd()
-			left := e.text.Width() - (e.Size().X - 1)
+			left := e.text.Width() - (screenWidth - 1)
 			if left >= 0 {
 				e.offset = left
 			}
@@ -109,7 +112,7 @@ func (e *TextEdit) OnKeyEvent(ev KeyEvent) {
 	}
 
 	e.text.WriteRune(ev.Rune)
-	if e.text.CursorPos(e.Size().X).X >= e.Size().X {
+	if e.text.CursorPos().X >= screenWidth {
 		e.offset++
 	}
 	if e.onTextChange != nil {

--- a/wordwrap/wordwrap.go
+++ b/wordwrap/wordwrap.go
@@ -1,0 +1,54 @@
+package wordwrap
+
+import (
+	"bytes"
+	"unicode"
+)
+
+// WrapString wraps the input string by inserting newline characters. It does
+// not remove whitespace, but preserves the original text.
+func WrapString(s string, width int) string {
+	if len(s) <= 1 {
+		return s
+	}
+
+	var buf bytes.Buffer
+	var word bytes.Buffer
+
+	word.WriteByte(s[0])
+
+	spaceLeft := width
+	for i := 1; i < len(s); i++ {
+		curr := s[i]
+		prev := s[i-1]
+
+		if curr == '\n' {
+			if word.Len() > spaceLeft {
+				spaceLeft = width
+				buf.WriteRune('\n')
+			} else {
+				spaceLeft = width
+			}
+			// fmt.Printf("33: writing %q with %d spaces remaining out of %d\n", word.String(), spaceLeft, width)
+			word.WriteTo(&buf)
+		} else if unicode.IsSpace(rune(prev)) && !unicode.IsSpace(rune(curr)) {
+			if word.Len() > spaceLeft {
+				spaceLeft = width - word.Len()
+				buf.WriteRune('\n')
+			} else {
+				spaceLeft -= word.Len()
+			}
+			// fmt.Printf("42: writing %q with %d spaces remaining out of %d\n", word.String(), spaceLeft, width)
+			word.WriteTo(&buf)
+		}
+		word.WriteByte(curr)
+	}
+
+	if word.Len() > spaceLeft {
+		buf.WriteRune('\n')
+	}
+	// fmt.Printf("51: writing %q with %d spaces remaining out of %d\n", word.String(), spaceLeft, width)
+	word.WriteTo(&buf)
+
+	return buf.String()
+}

--- a/wordwrap/wordwrap_test.go
+++ b/wordwrap/wordwrap_test.go
@@ -1,0 +1,34 @@
+package wordwrap
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSimple(t *testing.T) {
+	for _, tt := range []struct {
+		In    string
+		Width int
+		Out   string
+	}{
+		{"", 3, ""},
+		{"a", 3, "a"},
+		{"aa", 3, "aa"},
+		{"aa bb", 3, "aa \nbb"},
+		{"aa bb ddd", 7, "aa bb \nddd"},
+		{"aaa bb cc ddddd", 7, "aaa bb \ncc \nddddd"},
+		{"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis egestas nisl urna, vel accumsan libero bibendum id. In consectetur facilisis iaculis. Vivamus cursus hendrerit neque, et bibendum leo accumsan ac.", 20, "Lorem ipsum dolor \nsit amet, \nconsectetur \nadipiscing elit. \nDuis egestas nisl \nurna, vel accumsan \nlibero bibendum id. \nIn consectetur \nfacilisis iaculis. \nVivamus cursus \nhendrerit neque, et \nbibendum leo \naccumsan ac."},
+		{"aaa bb\n\ncc ddddd", 7, "aaa bb\n\ncc \nddddd"},
+		{"Nulla lorem magna, efficitur interdum ante at, convallis sodales nulla. Sed maximus tempor condimentum.\n\nNam et risus est. Cras ornare iaculis orci, sit amet fringilla nisl pharetra quis.", 30, "Nulla lorem magna, efficitur \ninterdum ante at, convallis \nsodales nulla. Sed maximus \ntempor condimentum.\n\nNam et risus est. Cras \nornare iaculis orci, sit amet \nfringilla nisl pharetra quis."},
+		{"Nulla lorem magna, efficitur interdum ante at, convallis sodales nulla. Sed maximus tempor condimentum.\n\nNam et risus est. Cras ornare iaculis orci, sit amet fringilla nisl pharetra quis.", 35, "Nulla lorem magna, efficitur \ninterdum ante at, convallis \nsodales nulla. Sed maximus tempor \ncondimentum.\n\nNam et risus est. Cras ornare \niaculis orci, sit amet fringilla \nnisl pharetra quis."},
+		{"\n\nNam et risus est.", 30, "\n\nNam et risus est."},
+		{"a\n\na\n\n", 6, "a\n\na\n\n"},
+	} {
+		t.Run("", func(t *testing.T) {
+			if got := WrapString(tt.In, tt.Width); got != tt.Out {
+				padding := strings.Repeat(".", tt.Width)
+				t.Fatalf("\n\ngot = \n\n%s\n%s\n%s\n\nwant = \n\n%s\n%s\n%s", padding, got, padding, padding, tt.Out, padding)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This replaces the [mitchellh/go-wordwrap](https://github.com/mitchellh/go-wordwrap) with a new wordwrap library that preserves whitespace, to enable better text navigation.