### PR TITLE
Make WithStyle behave as a stack

### DIFF
--- a/example/color/main.go
+++ b/example/color/main.go
@@ -5,6 +5,8 @@ import (
 )
 
 func main() {
+	okay := tui.NewLabel("Everything is fine.")
+
 	l := tui.NewList()
 	l.SetFocused(true)
 	l.AddItems("First row", "Second row", "Third row", "Fourth row", "Fifth row", "Sixth row")
@@ -16,7 +18,9 @@ func main() {
 	fatal := tui.NewLabel("FATAL: Cats and dogs are now living together.")
 	fatal.SetStyleName("fatal")
 
-	root := tui.NewVBox(l, warning, fatal)
+	okay2 := tui.NewLabel("Everything is still fine.")
+
+	root := tui.NewVBox(okay, l, warning, fatal, okay2)
 
 	t := tui.NewTheme()
 	t.SetStyle("list.item", tui.Style{Bg: tui.ColorCyan, Fg: tui.ColorMagenta})
@@ -26,6 +30,9 @@ func main() {
 	// individual labels.
 	t.SetStyle("label.fatal", tui.Style{Bg: tui.ColorDefault, Fg: tui.ColorRed})
 	t.SetStyle("label.warning", tui.Style{Bg: tui.ColorDefault, Fg: tui.ColorYellow})
+
+	normal := tui.Style{Bg: tui.ColorWhite, Fg: tui.ColorBlack}
+	t.SetStyle("normal", normal)
 
 	ui := tui.New(root)
 	ui.SetTheme(t)

--- a/painter.go
+++ b/painter.go
@@ -155,21 +155,17 @@ func (p *Painter) SetStyle(s Style) {
 	p.style = s
 }
 
-// RestoreStyle clears any style and restores it to the default.
-func (p *Painter) RestoreStyle() {
-	p.SetStyle(p.theme.Style("normal"))
-}
-
-// WithStyle decorates the painter with the style associated with an identifier.
+// WithStyle executes the provided function, with the Painter assigned the style with the given name.
 func (p *Painter) WithStyle(n string, fn func(*Painter)) {
 	if !p.theme.HasStyle(n) {
 		fn(p)
 		return
 	}
 
+	prev := p.style
 	p.SetStyle(p.theme.Style(n))
 	fn(p)
-	p.RestoreStyle()
+	p.SetStyle(prev)
 }
 
 // WithMask masks a painter to restrict painting within the given rectangle.

--- a/painter_test.go
+++ b/painter_test.go
@@ -213,6 +213,7 @@ func (s *testSurface) Size() image.Point {
 	return s.size
 }
 
+// String writes the testSurface's characters as a string.
 func (s *testSurface) String() string {
 	var buf bytes.Buffer
 	buf.WriteRune('\n')
@@ -223,6 +224,48 @@ func (s *testSurface) String() string {
 				if w := runeWidth(cell.Rune); w > 1 {
 					i += w - 1
 				}
+			} else {
+				buf.WriteRune(s.emptyCh)
+			}
+		}
+		buf.WriteRune('\n')
+	}
+	return buf.String()
+}
+
+// FgColors renders the testSurface's foreground colors, using the digit 0-7 for painted cells.
+func (s *testSurface) FgColors() string {
+	var buf bytes.Buffer
+	buf.WriteRune('\n')
+	for j := 0; j < s.size.Y; j++ {
+		for i := 0; i < s.size.X; i++ {
+			if cell, ok := s.cells[image.Point{i, j}]; ok {
+				color := cell.Style.Fg
+				if cell.Style.Reverse {
+					color = cell.Style.Bg
+				}
+				buf.WriteRune('0' + rune(color))
+			} else {
+				buf.WriteRune(s.emptyCh)
+			}
+		}
+		buf.WriteRune('\n')
+	}
+	return buf.String()
+}
+
+// BgColors renders the testSurface's background colors, using the digit 0-7 for painted cells.
+func (s *testSurface) BgColors() string {
+	var buf bytes.Buffer
+	buf.WriteRune('\n')
+	for j := 0; j < s.size.Y; j++ {
+		for i := 0; i < s.size.X; i++ {
+			if cell, ok := s.cells[image.Point{i, j}]; ok {
+				color := cell.Style.Bg
+				if cell.Style.Reverse {
+					color = cell.Style.Fg
+				}
+				buf.WriteRune('0' + rune(color))
 			} else {
 				buf.WriteRune(s.emptyCh)
 			}

--- a/painter_test.go
+++ b/painter_test.go
@@ -166,6 +166,132 @@ func TestMask_MaskWithinEmptyMaskIsHidden(t *testing.T) {
 	}
 }
 
+func TestWithStyle_ApplyStyle(t *testing.T) {
+	surface := newTestSurface(5, 5)
+
+	theme := NewTheme()
+	theme.SetStyle("explicit", Style{Fg: ColorWhite, Bg: ColorBlack})
+
+	p := NewPainter(surface, theme)
+	p.WithMask(image.Rect(0, 0, 5, 5), func(p *Painter) {
+		p.WithMask(image.Rect(1, 1, 4, 4), func(p *Painter) {
+			sz := p.surface.Size()
+			for x := 0; x < sz.X; x++ {
+				for y := 0; y < sz.Y; y++ {
+					p.DrawRune(x, y, ' ')
+				}
+			}
+
+			p.WithMask(image.Rect(2, 2, 4, 4), func(p *Painter) {
+				p.WithStyle("explicit", func(p *Painter) {
+					sz := p.surface.Size()
+					for x := 0; x < sz.X; x++ {
+						for y := 0; y < sz.Y; y++ {
+							p.DrawRune(x, y, '!')
+						}
+					}
+
+				})
+			})
+		})
+	})
+
+	wantFg := `
+.....
+.000.
+.022.
+.022.
+.....
+`
+
+	wantBg := `
+.....
+.000.
+.011.
+.011.
+.....
+`
+
+	if surface.FgColors() != wantFg {
+		t.Errorf("got = \n%s\n\nwant = \n%s", surface.FgColors(), wantFg)
+	}
+	if surface.BgColors() != wantBg {
+		t.Errorf("got = \n%s\n\nwant = \n%s", surface.BgColors(), wantBg)
+	}
+
+}
+
+func TestWithStyle_Stacks(t *testing.T) {
+	surface := newTestSurface(10, 10)
+
+	theme := NewTheme()
+	theme.SetStyle("explicit", Style{Fg: Color(3)})
+	theme.SetStyle("auxiliary", Style{Fg: Color(2)})
+
+	p := NewPainter(surface, theme)
+	p.WithMask(image.Rect(0, 0, 10, 10), func(p *Painter) {
+
+		// Set "explicit" and draw upper-left and upper-right.
+		p.WithStyle("explicit", func(p *Painter) {
+			p.WithMask(image.Rect(1, 1, 4, 4), func(p *Painter) {
+				sz := p.surface.Size()
+				for x := 0; x < sz.X; x++ {
+					for y := 0; y < sz.Y; y++ {
+						p.DrawRune(x, y, ' ')
+					}
+				}
+			})
+			// set "auxiliary" before drawing upper-right.
+			p.WithStyle("auxiliary", func(p *Painter) {
+				p.WithMask(image.Rect(7, 1, 9, 3), func(p *Painter) {
+					sz := p.surface.Size()
+					for x := 0; x < sz.X; x++ {
+						for y := 0; y < sz.Y; y++ {
+							p.DrawRune(x, y, ' ')
+						}
+					}
+				})
+			})
+			// Then draw bottom-right, falling back to "explicit".
+			p.WithMask(image.Rect(1, 6, 4, 9), func(p *Painter) {
+				sz := p.surface.Size()
+				for x := 0; x < sz.X; x++ {
+					for y := 0; y < sz.Y; y++ {
+						p.DrawRune(x, y, ' ')
+					}
+				}
+			})
+		})
+
+		// Use global default for bottom-right.
+		p.WithMask(image.Rect(6, 6, 9, 9), func(p *Painter) {
+			sz := p.surface.Size()
+			for x := 0; x < sz.X; x++ {
+				for y := 0; y < sz.Y; y++ {
+					p.DrawRune(x, y, ' ')
+				}
+			}
+		})
+	})
+
+	wantFg := `
+..........
+.333...22.
+.333...22.
+.333......
+..........
+..........
+.333..000.
+.333..000.
+.333..000.
+..........
+`
+
+	if surface.FgColors() != wantFg {
+		t.Errorf("got = \n%s\n\nwant = \n%s", surface.FgColors(), wantFg)
+	}
+}
+
 type testCell struct {
 	Rune  rune
 	Style Style


### PR DESCRIPTION
The current behavior is that `WIthStyle` sets a `Style` on the `Painter`; but when the `func` supplied to `WithStyle` is done, it resets to the default style of the entire program.

This is, IMO, the wrong behavior- and a cause behind at least why my attempt at resolving #60 wasn't working.

This uses the call stack of drawing to push/pop styles when `WithStyle` is called. Within the scope of a `WithStyle`, the style is applied; outside, it's whatever style was previously part of the `Painter`. It adds a demo (in `examples/`) of the issue, new functionality to `testSurface` to allow testing of colors, and a test for the expected behavior. This also removes `ResetStyle`, since that would essentially break the notion of style inheritance.