### PR TITLE
Make TestSurface public

### DIFF
--- a/box_test.go
+++ b/box_test.go
@@ -290,11 +290,11 @@ func TestBox_Draw(t *testing.T) {
 	for _, tt := range drawBoxTests {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
-			var surface *testSurface
+			var surface *TestSurface
 			if tt.size.X == 0 && tt.size.Y == 0 {
-				surface = newTestSurface(10, 5)
+				surface = NewTestSurface(10, 5)
 			} else {
-				surface = newTestSurface(tt.size.X, tt.size.Y)
+				surface = NewTestSurface(tt.size.X, tt.size.Y)
 			}
 
 			painter := NewPainter(surface, NewTheme())
@@ -398,7 +398,7 @@ func TestBox_Insert(t *testing.T) {
 	for _, tt := range insertWidgetTests {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
-			surface := newTestSurface(20, 10)
+			surface := NewTestSurface(20, 10)
 			painter := NewPainter(surface, NewTheme())
 
 			label0 := NewLabel("Test 0")
@@ -434,7 +434,7 @@ func TestBox_Prepend(t *testing.T) {
 │..................│
 └──────────────────┘
 `
-	surface := newTestSurface(20, 10)
+	surface := NewTestSurface(20, 10)
 	painter := NewPainter(surface, NewTheme())
 
 	label0 := NewLabel("Test 0")
@@ -464,7 +464,7 @@ func TestBox_Remove(t *testing.T) {
 │..................│
 └──────────────────┘
 `
-	surface := newTestSurface(20, 6)
+	surface := NewTestSurface(20, 6)
 	painter := NewPainter(surface, NewTheme())
 
 	label0 := NewLabel("Test 0")

--- a/button_test.go
+++ b/button_test.go
@@ -35,7 +35,7 @@ func TestButton_OnActivated(t *testing.T) {
 }
 
 func TestButton_Draw(t *testing.T) {
-	surface := newTestSurface(10, 5)
+	surface := NewTestSurface(10, 5)
 	painter := NewPainter(surface, NewTheme())
 
 	btn := NewButton("test")

--- a/cjk_test.go
+++ b/cjk_test.go
@@ -89,7 +89,7 @@ var drawCJKTests = []struct {
 
 func TestCJK_Label(t *testing.T) {
 	for _, tt := range drawCJKTests {
-		surface := newTestSurface(10, 4)
+		surface := NewTestSurface(10, 4)
 
 		painter := NewPainter(surface, NewTheme())
 		painter.Repaint(tt.setup())

--- a/entry_test.go
+++ b/entry_test.go
@@ -70,11 +70,11 @@ func TestEntry_Draw(t *testing.T) {
 	for _, tt := range drawEntryTests {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
-			var surface *testSurface
+			var surface *TestSurface
 			if tt.size.X == 0 && tt.size.Y == 0 {
-				surface = newTestSurface(10, 5)
+				surface = NewTestSurface(10, 5)
 			} else {
-				surface = newTestSurface(tt.size.X, tt.size.Y)
+				surface = NewTestSurface(tt.size.X, tt.size.Y)
 			}
 
 			painter := NewPainter(surface, NewTheme())
@@ -310,7 +310,7 @@ func TestEntry_Layout(t *testing.T) {
 	for _, tt := range layoutEntryTests {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
-			surface := newTestSurface(20, 5)
+			surface := NewTestSurface(20, 5)
 			painter := NewPainter(surface, NewTheme())
 			painter.Repaint(tt.setup())
 
@@ -326,7 +326,7 @@ func TestEntry_OnEvent(t *testing.T) {
 	e.SetText("Lorem ipsum")
 	e.SetFocused(true)
 
-	surface := newTestSurface(4, 1)
+	surface := NewTestSurface(4, 1)
 	painter := NewPainter(surface, NewTheme())
 	painter.Repaint(e)
 
@@ -389,7 +389,7 @@ func TestEntry_MoveToStartAndEnd(t *testing.T) {
 		e.text.SetMaxWidth(5)
 		e.offset = 6
 
-		surface := newTestSurface(5, 1)
+		surface := NewTestSurface(5, 1)
 		painter := NewPainter(surface, NewTheme())
 
 		t.Run("When cursor is moved to the start", func(t *testing.T) {
@@ -434,7 +434,7 @@ func TestEntry_OnKeyBackspaceEvent(t *testing.T) {
 		e.text.SetMaxWidth(5)
 		e.offset = 6
 
-		surface := newTestSurface(5, 1)
+		surface := NewTestSurface(5, 1)
 		painter := NewPainter(surface, NewTheme())
 
 		t.Run("When cursor is moved to the middle", func(t *testing.T) {

--- a/grid_test.go
+++ b/grid_test.go
@@ -204,7 +204,7 @@ var drawGridTests = []struct {
 func TestGrid_Draw(t *testing.T) {
 	for _, tt := range drawGridTests {
 		t.Run(tt.test, func(t *testing.T) {
-			surface := newTestSurface(tt.size.X, tt.size.Y)
+			surface := NewTestSurface(tt.size.X, tt.size.Y)
 			painter := NewPainter(surface, NewTheme())
 			painter.Repaint(tt.setup())
 

--- a/label_test.go
+++ b/label_test.go
@@ -94,7 +94,7 @@ wrap......
 
 func TestLabel_Draw(t *testing.T) {
 	for _, tt := range drawLabelTests {
-		surface := newTestSurface(10, 5)
+		surface := NewTestSurface(10, 5)
 
 		painter := NewPainter(surface, NewTheme())
 		painter.Repaint(tt.setup())

--- a/list_test.go
+++ b/list_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestList_Draw(t *testing.T) {
-	surface := newTestSurface(10, 5)
+	surface := NewTestSurface(10, 5)
 	painter := NewPainter(surface, NewTheme())
 
 	l := NewList()
@@ -28,7 +28,7 @@ bar
 }
 
 func TestList_RemoveItem(t *testing.T) {
-	surface := newTestSurface(5, 3)
+	surface := NewTestSurface(5, 3)
 	painter := NewPainter(surface, NewTheme())
 
 	l := NewList()

--- a/painter_test.go
+++ b/painter_test.go
@@ -1,13 +1,12 @@
 package tui
 
 import (
-	"bytes"
 	"image"
 	"testing"
 )
 
 func TestMask_Full(t *testing.T) {
-	surface := newTestSurface(10, 10)
+	surface := NewTestSurface(10, 10)
 
 	p := NewPainter(surface, NewTheme())
 	p.WithMask(image.Rect(0, 0, 10, 10), func(p *Painter) {
@@ -39,7 +38,7 @@ func TestMask_Full(t *testing.T) {
 }
 
 func TestMask_Inset(t *testing.T) {
-	surface := newTestSurface(10, 10)
+	surface := NewTestSurface(10, 10)
 
 	p := NewPainter(surface, NewTheme())
 	p.WithMask(image.Rect(0, 0, 10, 10), func(p *Painter) {
@@ -71,7 +70,7 @@ func TestMask_Inset(t *testing.T) {
 }
 
 func TestMask_FirstCell(t *testing.T) {
-	surface := newTestSurface(10, 10)
+	surface := NewTestSurface(10, 10)
 
 	p := NewPainter(surface, NewTheme())
 	p.WithMask(image.Rect(0, 0, 10, 10), func(p *Painter) {
@@ -103,7 +102,7 @@ func TestMask_FirstCell(t *testing.T) {
 }
 
 func TestMask_LastCell(t *testing.T) {
-	surface := newTestSurface(10, 10)
+	surface := NewTestSurface(10, 10)
 
 	p := NewPainter(surface, NewTheme())
 	p.WithMask(image.Rect(0, 0, 10, 10), func(p *Painter) {
@@ -135,7 +134,7 @@ func TestMask_LastCell(t *testing.T) {
 }
 
 func TestMask_MaskWithinEmptyMaskIsHidden(t *testing.T) {
-	surface := newTestSurface(10, 10)
+	surface := NewTestSurface(10, 10)
 
 	p := NewPainter(surface, NewTheme())
 	p.WithMask(image.Rect(0, 0, 0, 0), func(p *Painter) {
@@ -292,111 +291,3 @@ func TestWithStyle_Stacks(t *testing.T) {
 	}
 }
 
-type testCell struct {
-	Rune  rune
-	Style Style
-}
-
-type testSurface struct {
-	cells   map[image.Point]testCell
-	cursor  image.Point
-	size    image.Point
-	emptyCh rune
-}
-
-func newTestSurface(w, h int) *testSurface {
-	return &testSurface{
-		cells:   make(map[image.Point]testCell),
-		size:    image.Point{w, h},
-		emptyCh: '.',
-	}
-}
-
-func (s *testSurface) SetCell(x, y int, ch rune, style Style) {
-	s.cells[image.Point{x, y}] = testCell{
-		Rune:  ch,
-		Style: style,
-	}
-}
-
-func (s *testSurface) SetCursor(x, y int) {
-	s.cursor = image.Point{x, y}
-}
-
-func (s *testSurface) HideCursor() {
-	s.cursor = image.Point{}
-}
-
-func (s *testSurface) Begin() {
-	s.cells = make(map[image.Point]testCell)
-}
-
-func (s *testSurface) End() {
-	// NOP
-}
-
-func (s *testSurface) Size() image.Point {
-	return s.size
-}
-
-// String writes the testSurface's characters as a string.
-func (s *testSurface) String() string {
-	var buf bytes.Buffer
-	buf.WriteRune('\n')
-	for j := 0; j < s.size.Y; j++ {
-		for i := 0; i < s.size.X; i++ {
-			if cell, ok := s.cells[image.Point{i, j}]; ok {
-				buf.WriteRune(cell.Rune)
-				if w := runeWidth(cell.Rune); w > 1 {
-					i += w - 1
-				}
-			} else {
-				buf.WriteRune(s.emptyCh)
-			}
-		}
-		buf.WriteRune('\n')
-	}
-	return buf.String()
-}
-
-// FgColors renders the testSurface's foreground colors, using the digit 0-7 for painted cells.
-func (s *testSurface) FgColors() string {
-	var buf bytes.Buffer
-	buf.WriteRune('\n')
-	for j := 0; j < s.size.Y; j++ {
-		for i := 0; i < s.size.X; i++ {
-			if cell, ok := s.cells[image.Point{i, j}]; ok {
-				color := cell.Style.Fg
-				if cell.Style.Reverse {
-					color = cell.Style.Bg
-				}
-				buf.WriteRune('0' + rune(color))
-			} else {
-				buf.WriteRune(s.emptyCh)
-			}
-		}
-		buf.WriteRune('\n')
-	}
-	return buf.String()
-}
-
-// BgColors renders the testSurface's background colors, using the digit 0-7 for painted cells.
-func (s *testSurface) BgColors() string {
-	var buf bytes.Buffer
-	buf.WriteRune('\n')
-	for j := 0; j < s.size.Y; j++ {
-		for i := 0; i < s.size.X; i++ {
-			if cell, ok := s.cells[image.Point{i, j}]; ok {
-				color := cell.Style.Bg
-				if cell.Style.Reverse {
-					color = cell.Style.Fg
-				}
-				buf.WriteRune('0' + rune(color))
-			} else {
-				buf.WriteRune(s.emptyCh)
-			}
-		}
-		buf.WriteRune('\n')
-	}
-	return buf.String()
-}

--- a/painter_test.go
+++ b/painter_test.go
@@ -166,7 +166,7 @@ func TestMask_MaskWithinEmptyMaskIsHidden(t *testing.T) {
 }
 
 func TestWithStyle_ApplyStyle(t *testing.T) {
-	surface := newTestSurface(5, 5)
+	surface := NewTestSurface(5, 5)
 
 	theme := NewTheme()
 	theme.SetStyle("explicit", Style{Fg: ColorWhite, Bg: ColorBlack})
@@ -221,7 +221,7 @@ func TestWithStyle_ApplyStyle(t *testing.T) {
 }
 
 func TestWithStyle_Stacks(t *testing.T) {
-	surface := newTestSurface(10, 10)
+	surface := NewTestSurface(10, 10)
 
 	theme := NewTheme()
 	theme.SetStyle("explicit", Style{Fg: Color(3)})

--- a/progress_test.go
+++ b/progress_test.go
@@ -11,7 +11,7 @@ func TestProgress_Draw(t *testing.T) {
 	p.SetSizePolicy(Expanding, Minimum)
 	p.SetCurrent(50)
 
-	surface := newTestSurface(11, 2)
+	surface := NewTestSurface(11, 2)
 	painter := NewPainter(surface, NewTheme())
 	painter.Repaint(p)
 

--- a/scroll_area_test.go
+++ b/scroll_area_test.go
@@ -99,11 +99,11 @@ func TestScrollArea_Draw(t *testing.T) {
 	for _, tt := range drawScrollAreaTests {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
-			var surface *testSurface
+			var surface *TestSurface
 			if tt.size.X == 0 && tt.size.Y == 0 {
-				surface = newTestSurface(10, 5)
+				surface = NewTestSurface(10, 5)
 			} else {
-				surface = newTestSurface(tt.size.X, tt.size.Y)
+				surface = NewTestSurface(tt.size.X, tt.size.Y)
 			}
 			painter := NewPainter(surface, NewTheme())
 
@@ -209,11 +209,11 @@ func TestNestedScrollArea_Draw(t *testing.T) {
 	for _, tt := range drawNestedScrollAreaTests {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
-			var surface *testSurface
+			var surface *TestSurface
 			if tt.size.X == 0 && tt.size.Y == 0 {
-				surface = newTestSurface(10, 5)
+				surface = NewTestSurface(10, 5)
 			} else {
-				surface = newTestSurface(tt.size.X, tt.size.Y)
+				surface = NewTestSurface(tt.size.X, tt.size.Y)
 			}
 
 			painter := NewPainter(surface, NewTheme())

--- a/table_test.go
+++ b/table_test.go
@@ -110,11 +110,11 @@ func TestTable_Draw(t *testing.T) {
 	for _, tt := range drawTableTests {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
-			var surface *testSurface
+			var surface *TestSurface
 			if tt.size.X == 0 && tt.size.Y == 0 {
-				surface = newTestSurface(10, 5)
+				surface = NewTestSurface(10, 5)
 			} else {
-				surface = newTestSurface(tt.size.X, tt.size.Y)
+				surface = NewTestSurface(tt.size.X, tt.size.Y)
 			}
 
 			painter := NewPainter(surface, NewTheme())

--- a/testing.go
+++ b/testing.go
@@ -74,8 +74,8 @@ func (s *TestSurface) String() string {
 	return buf.String()
 }
 
-// FgColors renders the testSurface's foreground colors, using the digit 0-7 for painted cells.
-func (s *testSurface) FgColors() string {
+// FgColors renders the TestSurface's foreground colors, using the digit 0-7 for painted cells.
+func (s *TestSurface) FgColors() string {
 	var buf bytes.Buffer
 	buf.WriteRune('\n')
 	for j := 0; j < s.size.Y; j++ {
@@ -95,8 +95,8 @@ func (s *testSurface) FgColors() string {
 	return buf.String()
 }
 
-// BgColors renders the testSurface's background colors, using the digit 0-7 for painted cells.
-func (s *testSurface) BgColors() string {
+// BgColors renders the TestSurface's background colors, using the digit 0-7 for painted cells.
+func (s *TestSurface) BgColors() string {
 	var buf bytes.Buffer
 	buf.WriteRune('\n')
 	for j := 0; j < s.size.Y; j++ {

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,118 @@
+package tui
+
+import (
+	"bytes"
+	"image"
+)
+
+type testCell struct {
+	Rune  rune
+	Style Style
+}
+
+// A TestSurface implements the Surface interface with local buffers,
+// and provides accessors to check the output of a draw operation on the Surface.
+type TestSurface struct {
+	cells   map[image.Point]testCell
+	cursor  image.Point
+	size    image.Point
+	emptyCh rune
+}
+
+func NewTestSurface(w, h int) *TestSurface {
+	return &TestSurface{
+		cells:   make(map[image.Point]testCell),
+		size:    image.Point{w, h},
+		emptyCh: '.',
+	}
+}
+
+func (s *TestSurface) SetCell(x, y int, ch rune, style Style) {
+	s.cells[image.Point{x, y}] = testCell{
+		Rune:  ch,
+		Style: style,
+	}
+}
+
+func (s *TestSurface) SetCursor(x, y int) {
+	s.cursor = image.Point{x, y}
+}
+
+func (s *TestSurface) HideCursor() {
+	s.cursor = image.Point{}
+}
+
+func (s *TestSurface) Begin() {
+	s.cells = make(map[image.Point]testCell)
+}
+
+func (s *TestSurface) End() {
+	// NOP
+}
+
+func (s *TestSurface) Size() image.Point {
+	return s.size
+}
+
+// String writes the TestSurface's characters as a string.
+func (s *TestSurface) String() string {
+	var buf bytes.Buffer
+	buf.WriteRune('\n')
+	for j := 0; j < s.size.Y; j++ {
+		for i := 0; i < s.size.X; i++ {
+			if cell, ok := s.cells[image.Point{i, j}]; ok {
+				buf.WriteRune(cell.Rune)
+				if w := runeWidth(cell.Rune); w > 1 {
+					i += w - 1
+				}
+			} else {
+				buf.WriteRune(s.emptyCh)
+			}
+		}
+		buf.WriteRune('\n')
+	}
+	return buf.String()
+}
+
+// FgColors renders the testSurface's foreground colors, using the digit 0-7 for painted cells.
+func (s *testSurface) FgColors() string {
+	var buf bytes.Buffer
+	buf.WriteRune('\n')
+	for j := 0; j < s.size.Y; j++ {
+		for i := 0; i < s.size.X; i++ {
+			if cell, ok := s.cells[image.Point{i, j}]; ok {
+				color := cell.Style.Fg
+				if cell.Style.Reverse {
+					color = cell.Style.Bg
+				}
+				buf.WriteRune('0' + rune(color))
+			} else {
+				buf.WriteRune(s.emptyCh)
+			}
+		}
+		buf.WriteRune('\n')
+	}
+	return buf.String()
+}
+
+// BgColors renders the testSurface's background colors, using the digit 0-7 for painted cells.
+func (s *testSurface) BgColors() string {
+	var buf bytes.Buffer
+	buf.WriteRune('\n')
+	for j := 0; j < s.size.Y; j++ {
+		for i := 0; i < s.size.X; i++ {
+			if cell, ok := s.cells[image.Point{i, j}]; ok {
+				color := cell.Style.Bg
+				if cell.Style.Reverse {
+					color = cell.Style.Fg
+				}
+				buf.WriteRune('0' + rune(color))
+			} else {
+				buf.WriteRune(s.emptyCh)
+			}
+		}
+		buf.WriteRune('\n')
+	}
+	return buf.String()
+}
+

--- a/text_edit_test.go
+++ b/text_edit_test.go
@@ -34,11 +34,11 @@ func TestTextEdit_Draw(t *testing.T) {
 	for _, tt := range drawTextEditTests {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
-			var surface *testSurface
+			var surface *TestSurface
 			if tt.size.X == 0 && tt.size.Y == 0 {
-				surface = newTestSurface(10, 5)
+				surface = NewTestSurface(10, 5)
 			} else {
-				surface = newTestSurface(tt.size.X, tt.size.Y)
+				surface = NewTestSurface(tt.size.X, tt.size.Y)
 			}
 
 			painter := NewPainter(surface, NewTheme())


### PR DESCRIPTION
This adds a new public type, `tui.TestSurface`. Programmers using `tui` can use `TestSurface` to verify their own rendering patterns.

It's exactly the same as the previously-internal `testSurface` type; I just added the minimal docstring. It doesn't have any explicit tests, just the ones that `*_test.go` files already cover.

Fixes #66. Conflicts with #78, which adds `FgColor` and `BgColor`; I'll happily update the one that goes in second s.t. it merges cleanly.