### PR TITLE
Make Styles inherit by default

### DIFF
--- a/example/color/main.go
+++ b/example/color/main.go
@@ -4,35 +4,63 @@ import (
 	"github.com/marcusolsson/tui-go"
 )
 
+// StyledBox is a Box with an overriden Draw method.
+// Embedding a Widget within another allows overriding of some behaviors.
+type StyledBox struct {
+	Style string
+	*tui.Box
+}
+func (s *StyledBox) Draw(p *tui.Painter) {
+	p.WithStyle(s.Style, func(p *tui.Painter) {
+		s.Box.Draw(p)
+	})
+}
+
 func main() {
+	t := tui.NewTheme()
+	normal := tui.Style{Bg: tui.ColorWhite, Fg: tui.ColorBlack}
+	t.SetStyle("normal", normal)
+
+	// A simple label.
 	okay := tui.NewLabel("Everything is fine.")
 
+	// A list with some items selected.
 	l := tui.NewList()
 	l.SetFocused(true)
 	l.AddItems("First row", "Second row", "Third row", "Fourth row", "Fifth row", "Sixth row")
 	l.SetSelected(0)
 
-	warning := tui.NewLabel("WARNING: This is a warning")
-	warning.SetStyleName("warning")
-
-	fatal := tui.NewLabel("FATAL: Cats and dogs are now living together.")
-	fatal.SetStyleName("fatal")
-
-	okay2 := tui.NewLabel("Everything is still fine.")
-
-	root := tui.NewVBox(okay, l, warning, fatal, okay2)
-
-	t := tui.NewTheme()
 	t.SetStyle("list.item", tui.Style{Bg: tui.ColorCyan, Fg: tui.ColorMagenta})
 	t.SetStyle("list.item.selected", tui.Style{Bg: tui.ColorRed, Fg: tui.ColorWhite})
 
-	// The style name is appended to the widget name to support coloring of
+		// The style name is appended to the widget name to support coloring of
 	// individual labels.
-	t.SetStyle("label.fatal", tui.Style{Bg: tui.ColorDefault, Fg: tui.ColorRed})
+	warning := tui.NewLabel("WARNING: This is a warning")
+	warning.SetStyleName("warning")
 	t.SetStyle("label.warning", tui.Style{Bg: tui.ColorDefault, Fg: tui.ColorYellow})
 
-	normal := tui.Style{Bg: tui.ColorWhite, Fg: tui.ColorBlack}
-	t.SetStyle("normal", normal)
+	fatal := tui.NewLabel("FATAL: Cats and dogs are now living together.")
+	fatal.SetStyleName("fatal")
+	t.SetStyle("label.fatal", tui.Style{Bg: tui.ColorDefault, Fg: tui.ColorRed})
+
+	// Styles inherit properties of the parent widget by default;
+	// setting a property overrides only that property.
+	message1 := tui.NewLabel("This is an ")
+	emphasis := tui.NewLabel("important")
+	message2 := tui.NewLabel(" message from our sponsors.")
+	message := &StyledBox{
+		Style: "bsod",
+		Box: tui.NewHBox(message1, emphasis, message2, tui.NewSpacer()),
+	}
+
+	emphasis.SetStyleName("emphasis")
+	t.SetStyle("label.emphasis", tui.Style{Bold: tui.DecorationOn, Underline: tui.DecorationOn, Bg: tui.ColorRed})
+	t.SetStyle("bsod", tui.Style{Bg: tui.ColorCyan, Fg: tui.ColorWhite})
+
+	// Another unstyled label.
+	okay2 := tui.NewLabel("Everything is still fine.")
+
+	root := tui.NewVBox(okay, l, warning, fatal, message, okay2)
 
 	ui := tui.New(root)
 	ui.SetTheme(t)

--- a/painter.go
+++ b/painter.go
@@ -156,6 +156,7 @@ func (p *Painter) SetStyle(s Style) {
 }
 
 // WithStyle executes the provided function, with the Painter assigned the style with the given name.
+// If there's no Style with that name, it continues to use the same Style.
 func (p *Painter) WithStyle(n string, fn func(*Painter)) {
 	if !p.theme.HasStyle(n) {
 		fn(p)

--- a/painter.go
+++ b/painter.go
@@ -155,16 +155,11 @@ func (p *Painter) SetStyle(s Style) {
 	p.style = s
 }
 
-// WithStyle executes the provided function, with the Painter assigned the style with the given name.
-// If there's no Style with that name, it continues to use the same Style.
+// WithStyle executes the provided function with the named Style applied on top of the current one.
 func (p *Painter) WithStyle(n string, fn func(*Painter)) {
-	if !p.theme.HasStyle(n) {
-		fn(p)
-		return
-	}
-
 	prev := p.style
-	p.SetStyle(p.theme.Style(n))
+	new := prev.mergeIn(p.theme.Style(n))
+	p.SetStyle(new)
 	fn(p)
 	p.SetStyle(prev)
 }

--- a/painter_test.go
+++ b/painter_test.go
@@ -301,7 +301,7 @@ var styleInheritTests = []struct {
 		test: "no second style, keeps first",
 		theme: func() *Theme {
 			r := NewTheme()
-			r.SetStyle("first", Style{Fg: Color(3), Bold: true})
+			r.SetStyle("first", Style{Fg: Color(3), Bold: DecorationOn})
 			return r
 		},
 		wantFg: `
@@ -319,7 +319,7 @@ var styleInheritTests = []struct {
 		test: "empty second style, inherits from first",
 		theme: func() *Theme{
 			r := NewTheme()
-			r.SetStyle("first", Style{Fg: Color(3), Bold: true})
+			r.SetStyle("first", Style{Fg: Color(3), Bold: DecorationOn})
 			r.SetStyle("second", Style{})
 			return r
 		},

--- a/painter_test.go
+++ b/painter_test.go
@@ -334,7 +334,37 @@ var styleInheritTests = []struct {
 222..222..
 `,
 },
-
+	{
+		test: "second style overrides only explicit properties",
+		theme: func() *Theme{
+			r := NewTheme()
+			r.SetStyle("first", Style{Fg: Color(3), Bold: DecorationOn})
+			r.SetStyle("second", Style{Underline: DecorationOn})
+			return r
+		},
+		wantFg: `
+333..333..
+333..333..
+333..333..
+`,
+		wantDecorations: `
+222..666..
+222..666..
+222..666..
+`	},
+	{
+		test: "second style resets a previously set property",
+		theme: func() *Theme{
+			r := NewTheme()
+			r.SetStyle("first", Style{Bold: DecorationOn})
+			r.SetStyle("second", Style{Bold: DecorationOff})
+			return r
+		},
+		wantDecorations: `
+222..000..
+222..000..
+222..000..
+`	},
 }
 
 func TestWithStyle_Inherit(t *testing.T) {
@@ -368,7 +398,7 @@ func TestWithStyle_Inherit(t *testing.T) {
 			gotColors := surface.FgColors()
 			gotDecorations := surface.Decorations()
 
-			if gotColors != tt.wantFg {
+			if tt.wantFg != "" && gotColors != tt.wantFg {
 				t.Errorf("unexpected colors: got = \n%s\nwant = \n%s", gotColors, tt.wantFg)
 			}
 			if gotDecorations != tt.wantDecorations {

--- a/testing.go
+++ b/testing.go
@@ -92,9 +92,6 @@ func (s *TestSurface) FgColors() string {
 		for i := 0; i < s.size.X; i++ {
 			if cell, ok := s.cells[image.Point{i, j}]; ok {
 				color := cell.Style.Fg
-				if cell.Style.Reverse {
-					color = cell.Style.Bg
-				}
 				buf.WriteRune('0' + rune(color))
 			} else {
 				buf.WriteRune(s.emptyCh)
@@ -113,9 +110,6 @@ func (s *TestSurface) BgColors() string {
 		for i := 0; i < s.size.X; i++ {
 			if cell, ok := s.cells[image.Point{i, j}]; ok {
 				color := cell.Style.Bg
-				if cell.Style.Reverse {
-					color = cell.Style.Fg
-				}
 				buf.WriteRune('0' + rune(color))
 			} else {
 				buf.WriteRune(s.emptyCh)
@@ -137,13 +131,13 @@ func (s *TestSurface) Decorations() string {
 		for i := 0; i < s.size.X; i++ {
 			if cell, ok := s.cells[image.Point{i, j}]; ok {
 				mask := int64(0)
-				if cell.Style.Reverse {
+				if cell.Style.Reverse == DecorationOn {
 					mask |= 1
 				}
-				if cell.Style.Bold {
+				if cell.Style.Bold == DecorationOn {
 					mask |= 2
 				}
-				if cell.Style.Underline {
+				if cell.Style.Underline == DecorationOn {
 					mask |= 4
 				}
 				buf.WriteString(strconv.FormatInt(mask, 16))

--- a/theme.go
+++ b/theme.go
@@ -16,14 +16,45 @@ const (
 	ColorYellow
 )
 
-// Style determines how a cell should be painted.
-type Style struct {
-	Fg      Color
-	Bg      Color
-	Reverse bool
+// Decoration represents a bold/underline/etc. state
+type Decoration int
 
-	Bold      bool
-	Underline bool
+const (
+	DecorationInherit Decoration = iota
+	DecorationOn
+	DecorationOff
+)
+
+// Style determines how a cell should be painted.
+// The zero value uses default from
+type Style struct {
+	Fg Color
+	Bg Color
+
+	Reverse   Decoration
+	Bold      Decoration
+	Underline Decoration
+}
+
+// mergeIn returns the receiver Style, with any changes in delta applied.
+func (s Style) mergeIn(delta Style) Style {
+	result := s
+	if delta.Fg != ColorDefault {
+		result.Fg = delta.Fg
+	}
+	if delta.Bg != ColorDefault {
+		result.Bg = delta.Bg
+	}
+	if delta.Reverse != DecorationInherit {
+		result.Reverse = delta.Reverse
+	}
+	if delta.Bold != DecorationInherit {
+		result.Bold = delta.Bold
+	}
+	if delta.Underline != DecorationInherit {
+		result.Underline = delta.Underline
+	}
+	return result
 }
 
 // Theme defines the styles for a set of identifiers.
@@ -34,10 +65,10 @@ type Theme struct {
 // DefaultTheme is a theme with reasonable defaults.
 var DefaultTheme = &Theme{
 	styles: map[string]Style{
-		"list.item.selected":  {Reverse: true},
-		"table.cell.selected": {Reverse: true},
-		"button.focused":      {Reverse: true},
-		"box.focused":         {Reverse: true},
+		"list.item.selected":  {Reverse: DecorationOn},
+		"table.cell.selected": {Reverse: DecorationOn},
+		"button.focused":      {Reverse: DecorationOn},
+		"box.focused":         {Reverse: DecorationOn},
 	},
 }
 
@@ -54,11 +85,9 @@ func (p *Theme) SetStyle(n string, i Style) {
 }
 
 // Style returns the style associated with an identifier.
+// If there is no Style associated with the name, it returns a default Style.
 func (p *Theme) Style(name string) Style {
-	if c, ok := p.styles[name]; ok {
-		return c
-	}
-	return Style{Fg: ColorDefault, Bg: ColorDefault}
+	return p.styles[name]
 }
 
 // HasStyle returns whether an identifier is associated with an identifier.

--- a/theme.go
+++ b/theme.go
@@ -19,6 +19,7 @@ const (
 // Decoration represents a bold/underline/etc. state
 type Decoration int
 
+// Decoration modes: Inherit from parent widget, explicitly on, or explicitly off.
 const (
 	DecorationInherit Decoration = iota
 	DecorationOn

--- a/theme_test.go
+++ b/theme_test.go
@@ -1,0 +1,55 @@
+package tui
+
+import (
+	"testing"
+)
+
+var base = Style{Fg: ColorWhite, Bg: ColorBlack, Bold: DecorationOff, Underline: DecorationOff}
+
+var mergeTests = []struct {
+	test  string
+	chain []Style
+	want  Style
+}{
+	{
+		test: "zero inherits",
+		chain: []Style{
+			base,
+			Style{},
+		},
+		want: base,
+	},
+	{
+		test: "orthogonal inherits",
+		chain: []Style{
+			base,
+			Style{Reverse: DecorationOn},
+			Style{Bold: DecorationOn},
+		},
+		want: Style{Fg: ColorWhite, Bg: ColorBlack, Reverse: DecorationOn, Bold: DecorationOn, Underline: DecorationOff},
+	},
+	{
+		test: "serial inherits",
+		chain: []Style{
+			base,
+			Style{Reverse: DecorationOn, Bold: DecorationOn},
+			Style{Bold: DecorationOff},
+		},
+		want: Style{Fg: ColorWhite, Bg: ColorBlack, Reverse: DecorationOn, Bold: DecorationOff, Underline: DecorationOff},
+	},
+}
+
+func TestStyle_Merge(t *testing.T) {
+	for _, tt := range mergeTests {
+		tt := tt
+		t.Run(tt.test, func(t *testing.T) {
+			var got Style
+			for _, s := range tt.chain {
+				got = got.mergeIn(s)
+			}
+			if got != tt.want {
+				t.Errorf("got = \n%v\nwant = \n%v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ui_tcell.go
+++ b/ui_tcell.go
@@ -168,9 +168,9 @@ func (s *tcellSurface) SetCell(x, y int, ch rune, style Style) {
 	st := tcell.StyleDefault.Normal().
 		Foreground(convertColor(style.Fg, false)).
 		Background(convertColor(style.Bg, false)).
-		Reverse(style.Reverse).
-		Bold(style.Bold).
-		Underline(style.Underline)
+		Reverse(style.Reverse == DecorationOn).
+		Bold(style.Bold == DecorationOn).
+		Underline(style.Underline == DecorationOn)
 
 	s.screen.SetContent(x, y, ch, nil, st)
 }


### PR DESCRIPTION
Overall, this fixes #81 - it changes the semantics of `Style` to be a set of overrides on top of whatever the preexisting style is. The zero value for `Style` means "inherit everything".

`Style` changes in a backwards-incompatible way- makes `Reverse`, `Bold`, and `Underline` into tri-state values ("inherit", "on", and "off").

The included example (examples/color/main.go) isn't as clean as I'd like because it requires embedding- there's not a way to apply a style to one `Box` but not another, at the moment.

Follows #80; I'll rebase from there once merged. (I'm also open to suggestions on how to present stacked pull requests in a more sensible way.) Tagging #36 because it's a similar behavior.
