### PR TITLE
Add an IRC channel to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@ For an overview of the alternatives for writing terminal user interfaces, check 
 ## License
 
 tui-go is released under the [MIT License](LICENSE).
+
+## Contact
+
+If you're interested in chatting with users and contributors, join `#tui-go` on
+the [Freenode](https://freenode.net/) IRC network. (There's a web interface
+[here](https://webchat.freenode.net/), and instructions for IRC clients
+[here](https://freenode.net/kb/answer/chat).)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ tui-go is released under the [MIT License](LICENSE).
 ## Contact
 
 If you're interested in chatting with users and contributors, join
-[#tui-go](https://gophers.slack.com/messages/tui-gu) on
+[#tui-go](https://gophers.slack.com/messages/tui-go) on
 the [Gophers Slack](https://gophers.slack.com).
 If you're not already a part of the Slack workspace, you can join
 [here](https://invite.slack.golangbridge.org/). If you prefer a lower-bandwidth

--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ tui-go is released under the [MIT License](LICENSE).
 
 ## Contact
 
-If you're interested in chatting with users and contributors, join `#tui-go` on
-the [Freenode](https://freenode.net/) IRC network. (There's a web interface
-[here](https://webchat.freenode.net/), and instructions for IRC clients
-[here](https://freenode.net/kb/answer/chat).)
+If you're interested in chatting with users and contributors, join
+[#tui-go](https://gophers.slack.com/messages/tui-gu) on
+the [Gophers Slack](https://gophers.slack.com).
+If you're not already a part of the Slack workspace, you can join
+[here](https://invite.slack.golangbridge.org/). If you prefer a lower-bandwidth
+interface, see [this
+article](https://get.slack.help/hc/en-us/articles/201727913-Connect-to-Slack-over-IRC-and-XMPP)
+on connecting to Slack via IRC or XMPP.


### PR DESCRIPTION
It would be nice to have a forum for discussion / spitballing / etc. outside of the issue-tracking progress.

I welcome feedback including but not limited to:

- "It's the 21st century; we use Slack here."
- "Why not this other (network|name|.*)?"
- "No, let's track discussions in the issue tracker; drop this PR."