### PR TITLE
Update docstring on Padder

### DIFF
--- a/padder.go
+++ b/padder.go
@@ -5,6 +5,7 @@ import "image"
 var _ Widget = &Padder{}
 
 // Padder is a widget to fill out space.
+// It adds empty space of a specified size to the outside of its contained Widget.
 type Padder struct {
 	widget Widget
 
@@ -12,6 +13,8 @@ type Padder struct {
 }
 
 // NewPadder returns a new Padder.
+// The enclosed Widget is given horizontal margin of x on the right and x on the left,
+// and a vertical margin of y on the top and y on the bottom.
 func NewPadder(x, y int, w Widget) *Padder {
 	return &Padder{
 		widget:  w,


### PR DESCRIPTION
I was confused as to the semantics of `x` and `y`: does it pad *to* the specified size, e.g. "be sure you're at least X by Y", or is it "this much space around the outside"?

Apparently it's the latter, i.e. CSS style (without being able to specify top-vs-bottom, left-vs-right.) This is an attempt to make the docstring clearer on the matter.