### PR TITLE
Make Update calls synchronous

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -2,13 +2,18 @@ package tui
 
 // UI defines the operations needed by the underlying engine.
 type UI interface {
+	// Change the root widget of the UI.
 	SetWidget(w Widget)
 	SetTheme(p *Theme)
 	SetKeybinding(seq string, fn func())
 	ClearKeybindings()
 	SetFocusChain(ch FocusChain)
+	// Start the UI thread; wait for it to complete, either via error or Quit.
 	Run() error
+	// Schedule work in the UI thread and await its completion.
+	// Note that calling Update from the UI thread will result in deadlock.
 	Update(fn func())
+	// Shut down the UI thread.
 	Quit()
 }
 


### PR DESCRIPTION
Before this change, Update is a maybe-blocking operation. Specifically, if there's an Update queued already, your Update is going to block; however, if the queue is empty, it will return immediately... without
actually running the function.

The worst case is if Update is called within the event thread itself. In that case, Update may be able to be called exactly once... and then the second time, it will deadlock.

This change
- Makes the callbackFn channel unbuffered
- Wraps callbacks with a blocking channel

in order to make Update a synchronous operation. With this change, calling Update within the event thread will immediately lock up - making it much more obvious that your code is behaving poorly. 

Note that it's still possible for a user to call `Update` asynchrounously, if they desire- it's just spelled `go ui.Update` instead.


---

This solution brought to you by Slack discussion with @marcusolsson and
@ingcr3at1on, where we considered the inverse alternative: the default behavior being
```golang
func (ui *UI) Update(fn func()) {
  go func() {
    ui.events <- callbackFn{fn}
  }()
}
```
and blocking behavior explicitly implemented by the clients. IMO (and apparently consensus), blocking (or rather, joining) by default makes more sense, especially since it only takes three characters (two of which are a well-known keyword) for the caller to override.

This solution also brought to you in large part by "[What Color is Your Function?](http://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/)"
  