### PR TITLE
Add Logger interface

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,18 @@
+package tui
+
+import (
+	"io/ioutil"
+	"log"
+)
+
+var logger Logger = log.New(ioutil.Discard, "", 0)
+
+// Logger provides a interface for the standard logger.
+type Logger interface {
+	Printf(format string, args ...interface{})
+}
+
+// SetLogger sets the logger that is used in tui.
+func SetLogger(l Logger) {
+	logger = l
+}

--- a/ui_tcell.go
+++ b/ui_tcell.go
@@ -110,6 +110,8 @@ func (ui *tcellUI) Run() error {
 func (ui *tcellUI) handleEvent(ev event) {
 	switch e := ev.(type) {
 	case KeyEvent:
+		logger.Printf("Received key event: %s", e.Name())
+
 		for _, b := range ui.keybindings {
 			if b.match(e) {
 				b.handler()
@@ -119,9 +121,12 @@ func (ui *tcellUI) handleEvent(ev event) {
 		ui.root.OnKeyEvent(e)
 		ui.painter.Repaint(ui.root)
 	case callbackEvent:
+		// Gets stuck in a print loop when the logger is a widget.
+		//logger.Printf("Received callback event")
 		e.cbFn()
 		ui.painter.Repaint(ui.root)
 	case paintEvent:
+		logger.Printf("Received paint event")
 		ui.painter.Repaint(ui.root)
 	}
 }
@@ -145,6 +150,7 @@ func (ui *tcellUI) handleResizeEvent(ev *tcell.EventResize) {
 
 // Quit signals to the UI to start shutting down.
 func (ui *tcellUI) Quit() {
+	logger.Printf("Quitting")
 	ui.screen.Fini()
 	ui.quit <- struct{}{}
 }


### PR DESCRIPTION
This introduces a `tui.Logger` interface that is implemented by the standard logger.

To enable debug logging from tui:

```
f, _ := os.Create("debug.log")
defer f.Close()

tui.SetLogger(log.New(f, "", log.LstdFlags)
```

Since Logger is an interface we can let a widget implement it to provide logging within the application even. If the logger is a widget however, each log entry will call `Update` and which means that logging callback events results in a infinite print loop.

Fixes #47 