### PR TITLE
Handle errors from tcell

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ func main() {
 		tui.NewLabel("tui-go"),
 	)
 
-	ui := tui.New(box)
+	ui, err := tui.New(box)
+	if err != nil {
+		panic(err)
+	}
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {

--- a/example/audioplayer/main.go
+++ b/example/audioplayer/main.go
@@ -54,7 +54,10 @@ func main() {
 		status,
 	)
 
-	ui := tui.New(root)
+	ui, err := tui.New(root)
+	if err != nil {
+		panic(err)
+	}
 
 	library.OnItemActivated(func(t *tui.Table) {
 		p.play(songs[t.Selected()-1], func(curr, max int) {

--- a/example/chat/main.go
+++ b/example/chat/main.go
@@ -66,7 +66,10 @@ func main() {
 
 	root := tui.NewHBox(sidebar, chat)
 
-	ui := tui.New(root)
+	ui, err := tui.New(root)
+	if err != nil {
+		panic(err)
+	}
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {

--- a/example/color/main.go
+++ b/example/color/main.go
@@ -64,7 +64,10 @@ func main() {
 
 	root := tui.NewVBox(okay, l, warning, fatal, message, okay2)
 
-	ui := tui.New(root)
+	ui, err := tui.New(root)
+	if err != nil {
+		panic(err)
+	}
 	ui.SetTheme(t)
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 

--- a/example/editor/main.go
+++ b/example/editor/main.go
@@ -15,7 +15,10 @@ func main() {
 
 	root := tui.NewVBox(buffer, status)
 
-	ui := tui.New(root)
+	ui, err := tui.New(root)
+	if err != nil {
+		panic(err)
+	}
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {

--- a/example/http/main.go
+++ b/example/http/main.go
@@ -125,7 +125,10 @@ func main() {
 	theme := tui.NewTheme()
 	theme.SetStyle("box.focused.border", tui.Style{Fg: tui.ColorYellow, Bg: tui.ColorDefault})
 
-	ui := tui.New(root)
+	ui, err := tui.New(root)
+	if err != nil {
+		panic(err)
+	}
 	ui.SetTheme(theme)
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 

--- a/example/login/main.go
+++ b/example/login/main.go
@@ -57,7 +57,10 @@ func main() {
 
 	tui.DefaultFocusChain.Set(user, password, login, register)
 
-	ui := tui.New(root)
+	ui, err := tui.New(root)
+	if err != nil {
+		panic(err)
+	}
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {

--- a/example/mail/main.go
+++ b/example/mail/main.go
@@ -79,7 +79,10 @@ func main() {
 
 	root := tui.NewVBox(inbox, tui.NewLabel(""), mail)
 
-	ui := tui.New(root)
+	ui, err := tui.New(root)
+	if err != nil {
+		panic(err)
+	}
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 	ui.SetKeybinding("Shift+Alt+Up", func() { ui.Quit() })
 

--- a/example/multiview/main.go
+++ b/example/multiview/main.go
@@ -15,7 +15,10 @@ func main() {
 
 	root := tui.NewVBox(views[0])
 
-	ui := tui.New(root)
+	ui, err := tui.New(root)
+	if err != nil {
+		panic(err)
+	}
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 	ui.SetKeybinding("Left", func() {
 		currentView = clamp(currentView-1, 0, len(views)-1)

--- a/example/scroll/main.go
+++ b/example/scroll/main.go
@@ -20,7 +20,10 @@ func main() {
 	root.Append(scrollBox)
 	root.Append(tui.NewVBox(tui.NewSpacer()))
 
-	ui := tui.New(root)
+	ui, err := tui.New(root)
+	if err != nil {
+		panic(err)
+	}
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 	ui.SetKeybinding("Up", func() { s.Scroll(0, -1) })
 	ui.SetKeybinding("Down", func() { s.Scroll(0, 1) })

--- a/ui.go
+++ b/ui.go
@@ -22,7 +22,6 @@ type UI interface {
 }
 
 // New returns a new UI with a root widget.
-func New(root Widget) UI {
-	tcellui, _ := newTcellUI(root)
-	return tcellui
+func New(root Widget) (UI, error) {
+	return newTcellUI(root)
 }


### PR DESCRIPTION
In go.ui the call to `newTcellUI` might return an error that was ignored.
That would lead to panic if, for example, the terminal can't be found (e.g. running any example with environment variable `TERM=nonexisting`).