### PR TITLE
example: Change panic to log.Fatal

### DIFF
--- a/example/audioplayer/main.go
+++ b/example/audioplayer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/marcusolsson/tui-go"
@@ -56,7 +57,7 @@ func main() {
 
 	ui, err := tui.New(root)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
 	library.OnItemActivated(func(t *tui.Table) {
@@ -69,11 +70,12 @@ func main() {
 			})
 		})
 	})
+
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 	ui.SetKeybinding("q", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }
 

--- a/example/chat/main.go
+++ b/example/chat/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/marcusolsson/tui-go"
@@ -68,11 +69,12 @@ func main() {
 
 	ui, err := tui.New(root)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
+
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }

--- a/example/color/main.go
+++ b/example/color/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/marcusolsson/tui-go"
 )
 
@@ -66,12 +68,13 @@ func main() {
 
 	ui, err := tui.New(root)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
+
 	ui.SetTheme(t)
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }

--- a/example/editor/main.go
+++ b/example/editor/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/marcusolsson/tui-go"
 )
 
@@ -17,12 +19,13 @@ func main() {
 
 	ui, err := tui.New(root)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
+
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }
 

--- a/example/http/main.go
+++ b/example/http/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/ioutil"
+	"log"
 	"net/http"
 	"sort"
 	"strings"
@@ -127,12 +128,13 @@ func main() {
 
 	ui, err := tui.New(root)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
+
 	ui.SetTheme(theme)
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }

--- a/example/login/main.go
+++ b/example/login/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/marcusolsson/tui-go"
 )
 
@@ -59,11 +61,12 @@ func main() {
 
 	ui, err := tui.New(root)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
+
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }

--- a/example/mail/main.go
+++ b/example/mail/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/marcusolsson/tui-go"
 )
 
@@ -81,12 +83,13 @@ func main() {
 
 	ui, err := tui.New(root)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
+
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 	ui.SetKeybinding("Shift+Alt+Up", func() { ui.Quit() })
 
 	if err := ui.Run(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }

--- a/example/multiview/main.go
+++ b/example/multiview/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/marcusolsson/tui-go"
 )
 
@@ -17,8 +19,9 @@ func main() {
 
 	ui, err := tui.New(root)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
+
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 	ui.SetKeybinding("Left", func() {
 		currentView = clamp(currentView-1, 0, len(views)-1)
@@ -30,7 +33,7 @@ func main() {
 	})
 
 	if err := ui.Run(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }
 

--- a/example/scroll/main.go
+++ b/example/scroll/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	tui "github.com/marcusolsson/tui-go"
 )
 
@@ -22,8 +24,9 @@ func main() {
 
 	ui, err := tui.New(root)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
+
 	ui.SetKeybinding("Esc", func() { ui.Quit() })
 	ui.SetKeybinding("Up", func() { s.Scroll(0, -1) })
 	ui.SetKeybinding("Down", func() { s.Scroll(0, 1) })
@@ -31,6 +34,6 @@ func main() {
 	ui.SetKeybinding("Right", func() { s.Scroll(1, 0) })
 
 	if err := ui.Run(); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
panic leave a pretty ugly output when a tui application crashes. This changes all panics to log.Fatals instead.