### PR TITLE
Fix Table widget bug

### DIFF
--- a/table.go
+++ b/table.go
@@ -99,6 +99,10 @@ func (t *Table) Draw(p *Painter) {
 
 // OnKeyEvent handles an event and propagates it to all children.
 func (t *Table) OnKeyEvent(ev KeyEvent) {
+	if !t.IsFocused() {
+		return
+	}
+
 	switch ev.Key {
 	case KeyUp:
 		t.moveUp()


### PR DESCRIPTION
Hi!
I found faulty behavior on the Table widget. I think the Table widget should discard key events when it is not focused.
This code can see the changed behavior on this commit.

```
package main

import (
	"github.com/marcusolsson/tui-go"
	"log"
)

func main() {
	table1 := tui.NewTable(0, 0)
	table1.AppendRow(tui.NewLabel("1"))
	table1.AppendRow(tui.NewLabel("2"))
	table1.AppendRow(tui.NewLabel("3"))
	table1.AppendRow(tui.NewLabel("4"))

	table2 := tui.NewTable(0, 0)
	table2.AppendRow(tui.NewLabel("A"))
	table2.AppendRow(tui.NewLabel("B"))
	table2.AppendRow(tui.NewLabel("C"))
	table2.AppendRow(tui.NewLabel("D"))

	sfc := &tui.SimpleFocusChain{}
	sfc.Set(table1, table2)

	root := tui.NewVBox(
		tui.NewHBox(table1, table2),
		tui.NewSpacer(),
	)

	ui, err := tui.New(root)
	if err != nil {
		log.Fatal(err)
	}
	ui.SetFocusChain(sfc)
	ui.SetKeybinding("Esc", func() { ui.Quit() })
	if err := ui.Run(); err != nil {
		log.Fatal(err)
	}
}
```

Expected behavior:
![ok](https://user-images.githubusercontent.com/7306559/34942947-e24c4ea8-fa3c-11e7-9ba1-773edf193752.gif)

Actual behavior on master branch (f9e3651):
![bug](https://user-images.githubusercontent.com/7306559/34942959-e92e1224-fa3c-11e7-97ef-206a1e2f17d6.gif)
