### PR TITLE
Update focusedWidget field when SetFocusChain() called

### DIFF
--- a/ui_tcell.go
+++ b/ui_tcell.go
@@ -54,7 +54,16 @@ func (ui *tcellUI) SetTheme(t *Theme) {
 }
 
 func (ui *tcellUI) SetFocusChain(chain FocusChain) {
+	if ui.kbFocus.focusedWidget != nil {
+		ui.kbFocus.focusedWidget.SetFocused(false)
+	}
+
 	ui.kbFocus.chain = chain
+	ui.kbFocus.focusedWidget = chain.FocusDefault()
+
+	if ui.kbFocus.focusedWidget != nil {
+		ui.kbFocus.focusedWidget.SetFocused(true)
+	}
 }
 
 func (ui *tcellUI) SetKeybinding(seq string, fn func()) {


### PR DESCRIPTION
I think SetFocusChain() should set the focusedWidget field to DefaultWidget.

Because SimpleFocusChain.FocusNext()/FocusPrev() methods will be return nil if SimpleFocusChain.widgets does not include current widget. So application will be panic on the kbFocusController.OnKeyEvent(). This commit prevents this problem.

Minimal reproduction example:
```
package main

import (
	"github.com/marcusolsson/tui-go"
	"log"
)

func main() {
	b1 := tui.NewButton("Step1: Press enter key")
	fc1 := &tui.SimpleFocusChain{}
	fc1.Set(b1)
	firstView := tui.NewVBox(b1)

	b2 := tui.NewButton("Step2: Press tab key to crash this application")
	fc2 := &tui.SimpleFocusChain{}
	fc2.Set(b2)
	secondView := tui.NewVBox(b2)

	ui, err := tui.New(firstView)
	if err != nil {
		log.Fatal(err)
	}

	ui.SetFocusChain(fc1)
	b1.OnActivated(func(*tui.Button) {
		ui.SetWidget(secondView)
		ui.SetFocusChain(fc2)
	})
	ui.SetKeybinding("Esc", func() { ui.Quit() })

	if err := ui.Run(); err != nil {
		log.Fatal(err)
	}
}

```