### PR TITLE
Test for and fix a limit on Box size.

### DIFF
--- a/box.go
+++ b/box.go
@@ -329,7 +329,7 @@ func doLayout(ws []Widget, space int, a Alignment) []int {
 
 	// Distribute remaining space
 	for {
-		min := math.MaxInt8
+		min := math.MaxInt64
 		for i, s := range sizes {
 			p := alignedSizePolicy(a, ws[i])
 			if (p == Preferred || p == Minimum) && s <= min {


### PR DESCRIPTION
The code for `Box` layouts assumed that all widgets were less than `MaxInt8`
units wide, i.e. less than 127. This isn't the full width of a screen (my laptop
is currently configured to be 195 characters wide, and that's not even my widest
screen.)

As a result, some `Box`es would be limited to less than their full width in
certain circumstances, leading to [weird artifacts](https://asciinema.org/a/nm8FIBjAN8dFulFwgo2Gakpx2).

This PR
a) Adds a test that demonstrates the issue, using nested HBoxen
b) Uses MaxInt64 rather than Max8 to resolve the limitation.