### PR TITLE
ScrollArea SizeHint uses underlying widget

### DIFF
--- a/scroll_area.go
+++ b/scroll_area.go
@@ -32,11 +32,6 @@ func (s *ScrollArea) SizeHint() image.Point {
 	return image.Pt(15, 8)
 }
 
-// SizePolicy returns the default layout behavior.
-func (s *ScrollArea) SizePolicy() (SizePolicy, SizePolicy) {
-	return Preferred, Preferred
-}
-
 // Scroll shifts the views over the content.
 func (s *ScrollArea) Scroll(dx, dy int) {
 	s.topLeft.X += dx


### PR DESCRIPTION
Hi!
I'm not sure if this changed recently, because after updating the lib I found my scroll areas were only displaying 8 rows. 

The docs for the `ScrollArea.SizeHint` method suggest it is meant to return "the size hint of the underlying widget."

This PR is doing just that 😄 