### PR TITLE
Fix size hint for grids/tables with columns of uneven size

### DIFF
--- a/grid.go
+++ b/grid.go
@@ -129,15 +129,22 @@ func (g *Grid) SizeHint() image.Point {
 		return image.Point{}
 	}
 
-	var width int
+	var maxWidth int
 	for i := 0; i < g.cols; i++ {
-		width += g.columnWidth(i)
+		if w := g.columnWidth(i); w > maxWidth {
+			maxWidth = w
+		}
 	}
 
-	var height int
+	var maxHeight int
 	for j := 0; j < g.rows; j++ {
-		height += g.rowHeight(j)
+		if h := g.rowHeight(j); h > maxHeight {
+			maxHeight = h
+		}
 	}
+
+	width := maxWidth * g.cols
+	height := maxHeight * g.rows
 
 	if g.hasBorder {
 		width += g.cols + 1

--- a/grid_test.go
+++ b/grid_test.go
@@ -5,6 +5,30 @@ import (
 	"testing"
 )
 
+func TestGridSizeHint(t *testing.T) {
+	g := NewGrid(0, 0)
+	g.AppendRow(
+		NewLabel("foo"),
+		NewLabel("this is a long column"),
+		NewLabel("bar"),
+	)
+	g.SetBorder(true)
+
+	surface := NewTestSurface(g.SizeHint().X, g.SizeHint().Y)
+	painter := NewPainter(surface, NewTheme())
+	painter.Repaint(g)
+
+	want := `
+┌─────────────────────┬─────────────────────┬─────────────────────┐
+│foo..................│this is a long column│bar..................│
+└─────────────────────┴─────────────────────┴─────────────────────┘
+`
+
+	if diff := surfaceEquals(surface, want); diff != "" {
+		t.Error(diff)
+	}
+}
+
 var drawGridTests = []struct {
 	test  string
 	size  image.Point


### PR DESCRIPTION
Current size hint (total size of cells) for grids/tables is unintuitive since the size hint will be split across columns and rows.

This changes so that the size hint is big enough to fit the biggest cell.

Fixes #76