### PR TITLE
tui.New does not return err anymore, fix in examples/http/main.go

### DIFF
--- a/example/http/main.go
+++ b/example/http/main.go
@@ -126,10 +126,7 @@ func main() {
 	theme := tui.NewTheme()
 	theme.SetStyle("box.focused.border", tui.Style{Fg: tui.ColorYellow, Bg: tui.ColorDefault})
 
-	ui, err := tui.New(root)
-	if err != nil {
-		log.Fatal(err)
-	}
+	ui := tui.New(root)
 
 	ui.SetTheme(theme)
 	ui.SetKeybinding("Esc", func() { ui.Quit() })


### PR DESCRIPTION
I ran the example code, but it doesn't work anymore due to the api change of tui.

Apparently `tui.New` does not return `err` anymore, so I removed it and it works fine.