### PR TITLE
disable tcell-mouse until tui-go supports mouse events

### DIFF
--- a/ui_tcell.go
+++ b/ui_tcell.go
@@ -90,7 +90,6 @@ func (ui *tcellUI) Run() error {
 	}
 
 	ui.screen.SetStyle(tcell.StyleDefault)
-	ui.screen.EnableMouse()
 	ui.screen.Clear()
 
 	go func() {


### PR DESCRIPTION
Not sure if you're willing to merge this, since you're not working much on tui-go anymore. However.. since it's doubtful mouse events will be passed through anytime soon (maybe I will work on a PR someday to add this), this will disable it so users can at least allow selectable text, as currently this isn't possible.