### PR TITLE
Unsuppress panics

### DIFF
--- a/ui_tcell.go
+++ b/ui_tcell.go
@@ -88,10 +88,10 @@ func (ui *tcellUI) Run() error {
 		return err
 	}
 
+	failed := true
 	defer func() {
-		if r := recover(); r != nil {
+		if failed {
 			ui.screen.Fini()
-			logger.Printf("Panic: %s", r)
 		}
 	}()
 
@@ -119,6 +119,7 @@ func (ui *tcellUI) Run() error {
 	for {
 		select {
 		case <-ui.quit:
+			failed = false
 			return nil
 		case ev := <-ui.eventQueue:
 			ui.handleEvent(ev)


### PR DESCRIPTION
The tui-go handles the panic and write an error message to logger.  But, the output of logger.Printf() is discarded by default [[1]].
Therefore, the application is suddenly exited without any error messages, If panicked in the event handler.  In the current implementation, it is hard to understand what happened.

I fixed this problem.

[1]: https://github.com/marcusolsson/tui-go/blob/cd94d703fac144c572eb929177adc5ae9a082e8e/logger.go#L8