### PR TITLE
use .EqualFold instead of .ToLower

### DIFF
--- a/keybinding.go
+++ b/keybinding.go
@@ -10,5 +10,5 @@ type keybinding struct {
 }
 
 func (b *keybinding) match(ev KeyEvent) bool {
-	return strings.ToLower(b.sequence) == strings.ToLower(ev.Name())
+	return strings.EqualFold(b.sequence, ev.Name())
 }


### PR DESCRIPTION
This change is mostly to placate staticcheck, which gives the following warning:

keybinding.go:13:9: should use strings.EqualFold(a, b) instead of strings.ToLower(a) == strings.ToLower(b) (SA6005)

As mentioned in issue https://github.com/marcusolsson/tui-go/pull/146 , this change should be slightly more computationally efficient:

SA6005 – Inefficient string comparison with strings.ToLower or strings.ToUpper
Converting two strings to the same case and comparing them like so

if strings.ToLower(s1) == strings.ToLower(s2) {
...
}
is significantly more expensive than comparing them with strings.EqualFold(s1, s2). This is due to memory usage as well as computational complexity.

strings.ToLower will have to allocate memory for the new strings, as well as convert both strings fully, even if they differ on the very first byte. strings.EqualFold, on the other hand, compares the strings one character at a time. It doesn't need to create two intermediate strings and can return as soon as the first non-matching character has been found.

For a more in-depth explanation of this issue, see https://blog.digitalocean.com/how-to-efficiently-compare-strings-in-go/