### PR TITLE
use image Point{} instead of image ZP

### DIFF
--- a/box.go
+++ b/box.go
@@ -142,7 +142,7 @@ func (b *Box) Draw(p *Painter) {
 			}
 
 			p.WithMask(image.Rectangle{
-				Min: image.ZP,
+				Min: image.Point{},
 				Max: child.Size(),
 			}, func(p *Painter) {
 				child.Draw(p)

--- a/grid.go
+++ b/grid.go
@@ -87,7 +87,7 @@ func (g *Grid) Draw(p *Painter) {
 			if w, ok := g.cells[pos]; ok {
 				p.Translate(wp.X, wp.Y)
 				p.WithMask(image.Rectangle{
-					Min: image.ZP,
+					Min: image.Point{},
 					Max: w.Size(),
 				}, func(p *Painter) {
 					w.Draw(p)

--- a/painter.go
+++ b/painter.go
@@ -37,7 +37,7 @@ func NewPainter(s Surface, p *Theme) *Painter {
 		surface: s,
 		style:   p.Style("normal"),
 		mask: image.Rectangle{
-			Min: image.ZP,
+			Min: image.Point{},
 			Max: s.Size(),
 		},
 	}
@@ -68,7 +68,7 @@ func (p *Painter) End() {
 // Repaint clears the surface, draws the scene and flushes it.
 func (p *Painter) Repaint(w Widget) {
 	p.mask = image.Rectangle{
-		Min: image.ZP,
+		Min: image.Point{},
 		Max: p.surface.Size(),
 	}
 

--- a/runebuf.go
+++ b/runebuf.go
@@ -80,7 +80,7 @@ func (r *RuneBuffer) getSplitByLine(w int) []string {
 // CursorPos returns the coordinate for the cursor for a given width.
 func (r *RuneBuffer) CursorPos() image.Point {
 	if r.width == 0 {
-		return image.ZP
+		return image.Point{}
 	}
 
 	sp := r.SplitByLine()

--- a/scroll_area.go
+++ b/scroll_area.go
@@ -25,7 +25,7 @@ func NewScrollArea(w Widget) *ScrollArea {
 
 // MinSizeHint returns the minimum size the widget is allowed to be.
 func (s *ScrollArea) MinSizeHint() image.Point {
-	return image.ZP
+	return image.Point{}
 }
 
 // SizeHint returns the size hint of the underlying widget.

--- a/spacer.go
+++ b/spacer.go
@@ -16,12 +16,12 @@ func NewSpacer() *Spacer {
 
 // MinSizeHint returns the minimum size the widget is allowed to be.
 func (s *Spacer) MinSizeHint() image.Point {
-	return image.ZP
+	return image.Point{}
 }
 
 // SizeHint returns the recommended size for the spacer.
 func (s *Spacer) SizeHint() image.Point {
-	return image.ZP
+	return image.Point{}
 }
 
 // SizePolicy returns the default layout behavior.

--- a/table.go
+++ b/table.go
@@ -86,7 +86,7 @@ func (t *Table) Draw(p *Painter) {
 					p.FillRect(0, 0, size.X, size.Y)
 
 					p.WithMask(image.Rectangle{
-						Min: image.ZP,
+						Min: image.Point{},
 						Max: size,
 					}, func(p *Painter) {
 						w.Draw(p)

--- a/widget.go
+++ b/widget.go
@@ -65,7 +65,7 @@ func (w *WidgetBase) Size() image.Point {
 
 // SizeHint returns the size hint of the widget.
 func (w *WidgetBase) SizeHint() image.Point {
-	return image.ZP
+	return image.Point{}
 }
 
 // SetSizePolicy sets the size policy for horizontal and vertical directions.


### PR DESCRIPTION
(In this newest episode of placating staticcheck saga, follow along as we deprecate the zero point convenience variable...)

Travis CI is reporting a new warning on the development version of go. It causes the build to fail.

The issue is that there seemed to be a convenience variable in the image package to represent a point with x = 0 and y = 0, accessed by image.ZP (ZP for zero-point).

It seems like go authors are deprecating that because it is not strictly necessary... image.Point{} does the same thing because ints are initialized to 0 (the nil value). I suppose that it is also marginally safer, should multiple instances access the ZP variable by pointer and if one person mutated it. By having each zero point explicitly allocated there is less opportunity for mistakes. I have yet to see an official explanation, these are my own thoughts.


```

box.go:145:10: image.ZP is deprecated: Use a literal image.Point{} instead.  (SA1019)
grid.go:90:11: image.ZP is deprecated: Use a literal image.Point{} instead.  (SA1019)
painter.go:40:9: image.ZP is deprecated: Use a literal image.Point{} instead.  (SA1019)
painter.go:71:8: image.ZP is deprecated: Use a literal image.Point{} instead.  (SA1019)
runebuf.go:83:10: image.ZP is deprecated: Use a literal image.Point{} instead.  (SA1019)
scroll_area.go:28:9: image.ZP is deprecated: Use a literal image.Point{} instead.  (SA1019)
spacer.go:19:9: image.ZP is deprecated: Use a literal image.Point{} instead.  (SA1019)
spacer.go:24:9: image.ZP is deprecated: Use a literal image.Point{} instead.  (SA1019)
table.go:89:12: image.ZP is deprecated: Use a literal image.Point{} instead.  (SA1019)
widget.go:68:9: image.ZP is deprecated: Use a literal image.Point{} instead.  (SA1019)
```