### PR TITLE
CPU resources are not released after the app exits.

### DIFF
--- a/ui_tcell.go
+++ b/ui_tcell.go
@@ -103,6 +103,7 @@ func (ui *tcellUI) Run() error {
 	ui.screen.SetStyle(tcell.StyleDefault)
 	ui.screen.Clear()
 
+	stopGoroutine := false
 	go func() {
 		for {
 			switch ev := ui.screen.PollEvent().(type) {
@@ -113,7 +114,14 @@ func (ui *tcellUI) Run() error {
 			case *tcell.EventResize:
 				ui.handleResizeEvent(ev)
 			}
+
+			if stopGoroutine {
+				break
+			}
 		}
+	}()
+	defer func() {
+		stopGoroutine = true
 	}()
 
 	for {


### PR DESCRIPTION
Hello. I use your framework to develop a TUI file dialog, ["tfd"](https://github.com/Akatsuki-py/tfd).
This framework is great! But seems to have one bug. 
Apps created using this framework will not release CPU resources even if exit with ui.Quit().

For example, if you put time.Sleep(time.Second*10) in the last line in tui-go/example/login/main.go, you can confirm that the CPU resources are not released.

I don't know the details of this framework, but I thought this bug is caused by the for-loop in ui.Run() being kept running.
