### PR TITLE
custom style for lists

### DIFF
--- a/list.go
+++ b/list.go
@@ -28,7 +28,7 @@ func NewList() *List {
 // Draw draws the list.
 func (l *List) Draw(p *Painter) {
 	for i, item := range l.items {
-		style := "list.item"
+		style := l.style
 		if i == l.selected-l.pos {
 			style += ".selected"
 		}

--- a/list.go
+++ b/list.go
@@ -11,6 +11,7 @@ type List struct {
 	items    []string
 	selected int
 	pos      int
+	style    string
 
 	onItemActivated    func(*List)
 	onSelectionChanged func(*List)
@@ -20,6 +21,7 @@ type List struct {
 func NewList() *List {
 	return &List{
 		selected: -1,
+		style:    "list.item",
 	}
 }
 
@@ -35,6 +37,10 @@ func (l *List) Draw(p *Painter) {
 			p.DrawText(0, i, item)
 		})
 	}
+}
+
+func (l *List) SetStyle(style string) {
+	l.style = style
 }
 
 // SizeHint returns the recommended size for the list.


### PR DESCRIPTION
I've been writing a program which has many lists, for which the style is required to be different for some lists (highlighting can occur between lists)

This PR basically, allows for a new "root" style of a list object to manually changed however still following the pattern of `<yourstyle>` for the default and `<yourstyle>.selected` for the selected box.

This PR is backwards compatible with no interface changes 

Open to suggested design alternatives!